### PR TITLE
Install can detect existing /nix/receipt.json

### DIFF
--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -184,4 +184,8 @@ impl Action for ConfigureNix {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }

--- a/src/action/common/configure_nix_daemon_service.rs
+++ b/src/action/common/configure_nix_daemon_service.rs
@@ -212,6 +212,10 @@ impl Action for ConfigureNixDaemonService {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -181,6 +181,10 @@ impl Action for ConfigureShellProfile {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_directory.rs
+++ b/src/action/common/create_directory.rs
@@ -214,6 +214,10 @@ impl Action for CreateDirectory {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_file.rs
+++ b/src/action/common/create_file.rs
@@ -188,6 +188,10 @@ impl Action for CreateFile {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_group.rs
+++ b/src/action/common/create_group.rs
@@ -160,6 +160,10 @@ impl Action for CreateGroup {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -134,6 +134,10 @@ impl Action for CreateNixTree {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_or_append_file.rs
+++ b/src/action/common/create_or_append_file.rs
@@ -223,6 +223,10 @@ impl Action for CreateOrAppendFile {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_user.rs
+++ b/src/action/common/create_user.rs
@@ -254,6 +254,10 @@ impl Action for CreateUser {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/create_users_and_group.rs
+++ b/src/action/common/create_users_and_group.rs
@@ -229,6 +229,10 @@ impl Action for CreateUsersAndGroup {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/fetch_nix.rs
+++ b/src/action/common/fetch_nix.rs
@@ -115,6 +115,10 @@ impl Action for FetchNix {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/move_unpacked_nix.rs
+++ b/src/action/common/move_unpacked_nix.rs
@@ -106,6 +106,10 @@ impl Action for MoveUnpackedNix {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/place_channel_configuration.rs
+++ b/src/action/common/place_channel_configuration.rs
@@ -130,6 +130,10 @@ impl Action for PlaceChannelConfiguration {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -115,6 +115,10 @@ impl Action for PlaceNixConfiguration {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -168,6 +168,10 @@ impl Action for ProvisionNix {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/common/setup_default_profile.rs
+++ b/src/action/common/setup_default_profile.rs
@@ -181,6 +181,10 @@ impl Action for SetupDefaultProfile {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/bootstrap_volume.rs
+++ b/src/action/darwin/bootstrap_volume.rs
@@ -106,6 +106,10 @@ impl Action for BootstrapVolume {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/create_apfs_volume.rs
+++ b/src/action/darwin/create_apfs_volume.rs
@@ -289,6 +289,10 @@ impl Action for CreateApfsVolume {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/create_synthetic_objects.rs
+++ b/src/action/darwin/create_synthetic_objects.rs
@@ -98,6 +98,10 @@ impl Action for CreateSyntheticObjects {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/create_volume.rs
+++ b/src/action/darwin/create_volume.rs
@@ -130,6 +130,10 @@ impl Action for CreateVolume {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/enable_ownership.rs
+++ b/src/action/darwin/enable_ownership.rs
@@ -109,6 +109,10 @@ impl Action for EnableOwnership {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/encrypt_volume.rs
+++ b/src/action/darwin/encrypt_volume.rs
@@ -86,6 +86,10 @@ impl Action for EncryptVolume {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/kickstart_launchctl_service.rs
+++ b/src/action/darwin/kickstart_launchctl_service.rs
@@ -96,6 +96,10 @@ impl Action for KickstartLaunchctlService {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/darwin/unmount_volume.rs
+++ b/src/action/darwin/unmount_volume.rs
@@ -117,6 +117,10 @@ impl Action for UnmountVolume {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/linux/create_systemd_sysext.rs
+++ b/src/action/linux/create_systemd_sysext.rs
@@ -185,6 +185,10 @@ impl Action for CreateSystemdSysext {
         *action_state = ActionState::Uncompleted;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -98,6 +98,10 @@ impl Action for StartSystemdUnit {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/linux/systemd_sysext_merge.rs
+++ b/src/action/linux/systemd_sysext_merge.rs
@@ -102,6 +102,10 @@ impl Action for SystemdSysextMerge {
         *action_state = ActionState::Completed;
         Ok(())
     }
+
+    fn action_state(&self) -> ActionState {
+        self.action_state
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -13,11 +13,12 @@ pub trait Action: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
     // They should also have an `async fn plan(args...) -> Result<ActionState<Self>, Box<dyn std::error::Error + Send + Sync>>;`
     async fn execute(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
     async fn revert(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
+    fn action_state(&self) -> ActionState;
 }
 
 dyn_clone::clone_trait_object!(Action);
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy)]
 pub enum ActionState {
     Completed,
     // Only applicable to meta-actions that start multiple sub-actions.

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -3,7 +3,7 @@ use std::{
     process::ExitCode,
 };
 
-use crate::{plan::RECEIPT_LOCATION, BuiltinPlanner, InstallPlan, Planner, action::ActionState};
+use crate::{action::ActionState, plan::RECEIPT_LOCATION, BuiltinPlanner, InstallPlan, Planner};
 use clap::{ArgAction, Parser};
 use eyre::{eyre, WrapErr};
 
@@ -71,7 +71,6 @@ impl CommandExecute for Install {
                         if existing_receipt.actions.iter().all(|v| v.action_state() == ActionState::Completed) {
                             return Err(eyre!("Found existing plan in `/nix/receipt.json`, with the same settings, already completed, try uninstalling and reinstalling if Nix isn't working"))
                         }
-                        
                         existing_receipt
                     } ,
                     None => {

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -63,13 +63,13 @@ impl CommandExecute for Install {
                 match existing_receipt {
                     Some(existing_receipt) => {
                         if existing_receipt.planner.typetag_name() != chosen_planner.typetag_name() {
-                            return Err(eyre!("Found existing plan in `/nix/receipt.json` which used a different planner, try uninstalling the existing install"))
+                            return Err(eyre!("Found existing plan in `{RECEIPT_LOCATION}` which used a different planner, try uninstalling the existing install"))
                         }
                         if existing_receipt.planner.settings().map_err(|e| eyre!(e))? != chosen_planner.settings().map_err(|e| eyre!(e))? {
-                            return Err(eyre!("Found existing plan in `/nix/receipt.json` which used different planner settings, try uninstalling the existing install"))
+                            return Err(eyre!("Found existing plan in `{RECEIPT_LOCATION}` which used different planner settings, try uninstalling the existing install"))
                         }
                         if existing_receipt.actions.iter().all(|v| v.action_state() == ActionState::Completed) {
-                            return Err(eyre!("Found existing plan in `/nix/receipt.json`, with the same settings, already completed, try uninstalling and reinstalling if Nix isn't working"))
+                            return Err(eyre!("Found existing plan in `{RECEIPT_LOCATION}`, with the same settings, already completed, try uninstalling and reinstalling if Nix isn't working"))
                         }
                         existing_receipt
                     } ,

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -1,6 +1,9 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::{
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
 
-use crate::BuiltinPlanner;
+use crate::{plan::RECEIPT_LOCATION, BuiltinPlanner, InstallPlan, Planner};
 use clap::{ArgAction, Parser};
 use eyre::{eyre, WrapErr};
 
@@ -8,7 +11,7 @@ use crate::{cli::CommandExecute, interaction};
 
 /// Execute an install (possibly using an existing plan)
 #[derive(Debug, Parser)]
-#[command(args_conflicts_with_subcommands = true)]
+#[command(args_conflicts_with_subcommands = true, arg_required_else_help = true)]
 pub struct Install {
     #[clap(
         long,
@@ -29,7 +32,7 @@ pub struct Install {
     pub plan: Option<PathBuf>,
 
     #[clap(subcommand)]
-    pub planner: BuiltinPlanner,
+    pub planner: Option<BuiltinPlanner>,
 }
 
 #[async_trait::async_trait]
@@ -43,28 +46,61 @@ impl CommandExecute for Install {
             explain,
         } = self;
 
-        let mut plan = match &plan {
-            Some(plan_path) => {
-                let install_plan_string = tokio::fs::read_to_string(&plan_path)
+        let existing_receipt: Option<InstallPlan> = match Path::new(RECEIPT_LOCATION).exists() {
+            true => {
+                let install_plan_string = tokio::fs::read_to_string(&RECEIPT_LOCATION)
                     .await
                     .wrap_err("Reading plan")?;
+                Some(serde_json::from_str(&install_plan_string)?)
+            },
+            false => None,
+        };
+
+        let mut install_plan = match (planner, plan) {
+            (Some(planner), None) => {
+                let chosen_planner: Box<dyn Planner> = planner.clone().boxed();
+
+                match existing_receipt {
+                    Some(existing_receipt) => {
+                        if existing_receipt.planner.typetag_name() == chosen_planner.typetag_name() {
+                            existing_receipt
+                        } else {
+                            return Err(eyre!("Found existing plan in `/nix/receipt.json` which used a different planner, try uninstalling the existing install"))
+                        }
+                    } ,
+                    None => {
+                        planner.plan().await.map_err(|e| eyre!(e))?
+                    },
+                }
+            },
+            (None, Some(plan_path)) => {
+                let install_plan_string = tokio::fs::read_to_string(&plan_path)
+                .await
+                .wrap_err("Reading plan")?;
                 serde_json::from_str(&install_plan_string)?
             },
-            None => planner.plan().await.map_err(|e| eyre!(e))?,
+            (None, None) => return Err(eyre!("`--plan` or a planner is required")),
+            (Some(_), Some(_)) => return Err(eyre!("`--plan` conflicts with passing a planner, a planner creates plans, so passing an existing plan doesn't make sense")),
         };
 
         if !no_confirm {
-            if !interaction::confirm(plan.describe_execute(explain).map_err(|e| eyre!(e))?).await? {
+            if !interaction::confirm(
+                install_plan
+                    .describe_execute(explain)
+                    .map_err(|e| eyre!(e))?,
+            )
+            .await?
+            {
                 interaction::clean_exit_with_message("Okay, didn't do anything! Bye!").await;
             }
         }
 
-        if let Err(err) = plan.install().await {
+        if let Err(err) = install_plan.install().await {
             tracing::error!("{:?}", eyre!(err));
-            if !interaction::confirm(plan.describe_revert(explain)).await? {
+            if !interaction::confirm(install_plan.describe_revert(explain)).await? {
                 interaction::clean_exit_with_message("Okay, didn't do anything! Bye!").await;
             }
-            plan.revert().await?
+            install_plan.revert().await?
         }
 
         Ok(ExitCode::SUCCESS)

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, process::ExitCode};
 
-use crate::InstallPlan;
+use crate::{plan::RECEIPT_LOCATION, InstallPlan};
 use clap::{ArgAction, Parser};
 use eyre::WrapErr;
 
@@ -23,7 +23,7 @@ pub struct Uninstall {
         global = true
     )]
     pub explain: bool,
-    #[clap(default_value = "/nix/receipt.json")]
+    #[clap(default_value = RECEIPT_LOCATION)]
     pub receipt: PathBuf,
 }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -45,7 +45,7 @@ impl InstallPlan {
             },
             planner = planner.typetag_name(),
             plan_settings = planner
-                .describe()?
+                .settings()?
                 .into_iter()
                 .map(|(k, v)| format!("* {k}: {v}", k = k.bold().white()))
                 .collect::<Vec<_>>()

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -8,6 +8,8 @@ use crate::{
     HarmonicError,
 };
 
+pub const RECEIPT_LOCATION: &str = "/nix/receipt.json";
+
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct InstallPlan {
     pub(crate) actions: Vec<Box<dyn Action>>,
@@ -166,7 +168,7 @@ async fn write_receipt(plan: InstallPlan) -> Result<(), HarmonicError> {
     tokio::fs::create_dir_all("/nix")
         .await
         .map_err(|e| HarmonicError::RecordingReceipt(PathBuf::from("/nix"), e))?;
-    let install_receipt_path = PathBuf::from("/nix/receipt.json");
+    let install_receipt_path = PathBuf::from(RECEIPT_LOCATION);
     let self_json =
         serde_json::to_string_pretty(&plan).map_err(HarmonicError::SerializingReceipt)?;
     tokio::fs::write(&install_receipt_path, self_json)

--- a/src/planner/darwin/multi.rs
+++ b/src/planner/darwin/multi.rs
@@ -98,7 +98,7 @@ impl Planner for DarwinMulti {
         })
     }
 
-    fn describe(
+    fn settings(
         &self,
     ) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Sync + Send>> {
         let Self {

--- a/src/planner/linux/multi.rs
+++ b/src/planner/linux/multi.rs
@@ -36,7 +36,7 @@ impl Planner for LinuxMulti {
         })
     }
 
-    fn describe(
+    fn settings(
         &self,
     ) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Sync + Send>> {
         let Self { settings } = self;

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -13,7 +13,7 @@ pub trait Planner: std::fmt::Debug + Send + Sync + dyn_clone::DynClone {
     where
         Self: Sized;
     async fn plan(self) -> Result<InstallPlan, Box<dyn std::error::Error + Sync + Send>>;
-    fn describe(
+    fn settings(
         &self,
     ) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Sync + Send>>;
     fn boxed(self) -> Box<dyn Planner>

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -16,6 +16,12 @@ pub trait Planner: std::fmt::Debug + Send + Sync + dyn_clone::DynClone {
     fn describe(
         &self,
     ) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Sync + Send>>;
+    fn boxed(self) -> Box<dyn Planner>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
 }
 
 dyn_clone::clone_trait_object!(Planner);
@@ -54,6 +60,13 @@ impl BuiltinPlanner {
             BuiltinPlanner::LinuxMulti(planner) => planner.plan().await,
             BuiltinPlanner::DarwinMulti(planner) => planner.plan().await,
             BuiltinPlanner::SteamDeck(planner) => planner.plan().await,
+        }
+    }
+    pub fn boxed(self) -> Box<dyn Planner> {
+        match self {
+            BuiltinPlanner::LinuxMulti(i) => i.boxed(),
+            BuiltinPlanner::DarwinMulti(i) => i.boxed(),
+            BuiltinPlanner::SteamDeck(i) => i.boxed(),
         }
     }
 }

--- a/src/planner/specific/steam_deck.rs
+++ b/src/planner/specific/steam_deck.rs
@@ -36,7 +36,7 @@ impl Planner for SteamDeck {
         })
     }
 
-    fn describe(
+    fn settings(
         &self,
     ) -> Result<HashMap<String, serde_json::Value>, Box<dyn std::error::Error + Sync + Send>> {
         let Self { settings } = self;


### PR DESCRIPTION
Fixes #30.

Now when a user passes a planner/plan we check for an existing receipt, ensure it's compatible (the same planner **and** settings) and that it's not already completed, then it will attempt to resume the existing install as if the user accidently Ctrl+C'd.

In the future, we'll probably want to prompt the user differently.