### PR TITLE
Tidy up plan / install UX

### DIFF
--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -10,8 +10,10 @@ use eyre::{eyre, WrapErr};
 use crate::{cli::CommandExecute, interaction};
 
 /// Execute an install (possibly using an existing plan)
+///
+/// To pass custom options, select a planner, for example `harmonic install linux-multi --help`
 #[derive(Debug, Parser)]
-#[command(args_conflicts_with_subcommands = true, arg_required_else_help = true)]
+#[command(args_conflicts_with_subcommands = true)]
 pub struct Install {
     #[clap(
         long,

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -29,7 +29,7 @@ pub struct Install {
     pub plan: Option<PathBuf>,
 
     #[clap(subcommand)]
-    pub planner: BuiltinPlanner,
+    pub planner: Option<BuiltinPlanner>,
 }
 
 #[async_trait::async_trait]
@@ -42,6 +42,13 @@ impl CommandExecute for Install {
             planner,
             explain,
         } = self;
+
+        let planner = match planner {
+            Some(planner) => planner,
+            None => BuiltinPlanner::default()
+                .await
+                .map_err(|e| eyre::eyre!(e))?,
+        };
 
         let mut plan = match &plan {
             Some(plan_path) => {

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -9,11 +9,10 @@ use crate::cli::CommandExecute;
 
 /// Plan an install that can be repeated on an identical host later
 #[derive(Debug, Parser)]
-#[command(args_conflicts_with_subcommands = true, arg_required_else_help = true)]
 pub struct Plan {
     #[clap(subcommand)]
     pub planner: Option<BuiltinPlanner>,
-    #[clap(env = "HARMONIC_PLAN")]
+    #[clap(env = "HARMONIC_PLAN", default_value = "/dev/stdout")]
     pub output: PathBuf,
 }
 


### PR DESCRIPTION
Users shouldn't need to pass a planner if there exists a default for their platform, however if they want to specify options they do need to specify a planner.

I was looking at how to do it so the default planner options were available without passing it, but I think the API gets very murky at that point.