### PR TITLE
Add plan tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ typetag = "0.2.3"
 dyn-clone = "1.0.9"
 rand = "0.8.5"
 semver = { version = "1.0.14", features = ["serde"] }
+
+[dev-dependencies]
+eyre = "0.6.8"

--- a/tests/fixtures/darwin/darwin-multi.json
+++ b/tests/fixtures/darwin/darwin-multi.json
@@ -1,0 +1,671 @@
+{
+    "version": "0.0.0-unreleased",
+    "actions": [
+        {
+            "action": {
+                "action": "create_apfs_volume",
+                "disk": "disk1",
+                "name": "Nix Store",
+                "case_sensitive": false,
+                "encrypt": true,
+                "create_or_append_synthetic_conf": {
+                    "action": {
+                        "path": "/etc/synthetic.conf",
+                        "user": null,
+                        "group": null,
+                        "mode": 429,
+                        "buf": "nix\n"
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_synthetic_objects": {
+                    "action": null,
+                    "state": "Uncompleted"
+                },
+                "unmount_volume": {
+                    "action": {
+                        "disk": "disk1",
+                        "name": "Nix Store"
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_volume": {
+                    "action": {
+                        "disk": "disk1",
+                        "name": "Nix Store",
+                        "case_sensitive": false
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_or_append_fstab": {
+                    "action": {
+                        "path": "/etc/fstab",
+                        "user": null,
+                        "group": null,
+                        "mode": 429,
+                        "buf": "NAME=\"Nix Store\" /nix apfs rw,noauto,nobrowse,suid,owners"
+                    },
+                    "state": "Uncompleted"
+                },
+                "encrypt_volume": {
+                    "action": {
+                        "disk": "disk1",
+                        "name": "Nix Store"
+                    },
+                    "state": "Uncompleted"
+                },
+                "setup_volume_daemon": {
+                    "action": {
+                        "path": "/Library/LaunchDaemons/org.nixos.darwin-store.plist",
+                        "user": null,
+                        "group": null,
+                        "mode": null,
+                        "buf": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n<key>RunAtLoad</key>\n<true/>\n<key>Label</key>\n<string>org.nixos.darwin-store</string>\n<key>ProgramArguments</key>\n<array>\n<string>/bin/sh</string>\n\n<string>-c</string>\n\n<string>/usr/bin/security find-generic-password -s \"Nix Store\" -w |  /usr/sbin/diskutil apfs unlockVolume \"Nix Store\" -mountpoint /nix -stdinpassphrase</string>\n</array>\n</dict>\n</plist>\n",
+                        "force": false
+                    },
+                    "state": "Uncompleted"
+                },
+                "bootstrap_volume": {
+                    "action": {
+                        "path": "/Library/LaunchDaemons/org.nixos.darwin-store.plist"
+                    },
+                    "state": "Uncompleted"
+                },
+                "enable_ownership": {
+                    "action": {
+                        "path": "/nix"
+                    },
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "provision_nix",
+                "fetch_nix": {
+                    "action": {
+                        "url": "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-darwin.tar.xz",
+                        "dest": "/nix/temp-install-dir"
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_users_and_group": {
+                    "action": {
+                        "daemon_user_count": 32,
+                        "nix_build_group_name": "nixbld",
+                        "nix_build_group_id": 3000,
+                        "nix_build_user_prefix": "_nixbld",
+                        "nix_build_user_id_base": 300,
+                        "create_group": {
+                            "action": {
+                                "name": "nixbld",
+                                "gid": 3000
+                            },
+                            "state": "Uncompleted"
+                        },
+                        "create_users": [
+                            {
+                                "action": {
+                                    "name": "_nixbld0",
+                                    "uid": 300,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld1",
+                                    "uid": 301,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld2",
+                                    "uid": 302,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld3",
+                                    "uid": 303,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld4",
+                                    "uid": 304,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld5",
+                                    "uid": 305,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld6",
+                                    "uid": 306,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld7",
+                                    "uid": 307,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld8",
+                                    "uid": 308,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld9",
+                                    "uid": 309,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld10",
+                                    "uid": 310,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld11",
+                                    "uid": 311,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld12",
+                                    "uid": 312,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld13",
+                                    "uid": 313,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld14",
+                                    "uid": 314,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld15",
+                                    "uid": 315,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld16",
+                                    "uid": 316,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld17",
+                                    "uid": 317,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld18",
+                                    "uid": 318,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld19",
+                                    "uid": 319,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld20",
+                                    "uid": 320,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld21",
+                                    "uid": 321,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld22",
+                                    "uid": 322,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld23",
+                                    "uid": 323,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld24",
+                                    "uid": 324,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld25",
+                                    "uid": 325,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld26",
+                                    "uid": 326,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld27",
+                                    "uid": 327,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld28",
+                                    "uid": 328,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld29",
+                                    "uid": 329,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld30",
+                                    "uid": 330,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "_nixbld31",
+                                    "uid": 331,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_nix_tree": {
+                    "action": {
+                        "create_directories": [
+                            {
+                                "action": {
+                                    "path": "/nix/var",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log/nix",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log/nix/drvs",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/db",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/gcroots",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/gcroots/per-user",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/profiles",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/profiles/per-user",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/temproots",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/userpool",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/daemon-socket",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "move_unpacked_nix": {
+                    "action": {
+                        "src": "/nix/temp-install-dir"
+                    },
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "configure_nix",
+                "setup_default_profile": {
+                    "action": {
+                        "channels": [
+                            "nixpkgs"
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "configure_shell_profile": {
+                    "action": {
+                        "create_or_append_files": [
+                            {
+                                "action": {
+                                    "path": "/etc/bashrc",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 420,
+                                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n. '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n            \n"
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/etc/zshrc",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 420,
+                                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n. '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n            \n"
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "place_channel_configuration": {
+                    "action": {
+                        "channels": [
+                            [
+                                "nixpkgs",
+                                "https://nixos.org/channels/nixpkgs-unstable"
+                            ]
+                        ],
+                        "create_file": {
+                            "action": {
+                                "path": "/Users/ephemeraladmin/.nix-channels",
+                                "user": null,
+                                "group": null,
+                                "mode": 436,
+                                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs",
+                                "force": false
+                            },
+                            "state": "Uncompleted"
+                        }
+                    },
+                    "state": "Uncompleted"
+                },
+                "place_nix_configuration": {
+                    "action": {
+                        "create_directory": {
+                            "action": {
+                                "path": "/etc/nix",
+                                "user": null,
+                                "group": null,
+                                "mode": 493,
+                                "force_prune_on_revert": false
+                            },
+                            "state": "Uncompleted"
+                        },
+                        "create_file": {
+                            "action": {
+                                "path": "/etc/nix/nix.conf",
+                                "user": null,
+                                "group": null,
+                                "mode": 436,
+                                "buf": "\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n",
+                                "force": false
+                            },
+                            "state": "Uncompleted"
+                        }
+                    },
+                    "state": "Uncompleted"
+                },
+                "configure_nix_daemon_service": {
+                    "action": {},
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "kickstart_launchctl_service",
+                "unit": "system/org.nixos.nix-daemon"
+            },
+            "state": "Uncompleted"
+        }
+    ],
+    "planner": {
+        "planner": "darwin-multi",
+        "settings": {
+            "channels": [
+                [
+                    "nixpkgs",
+                    "https://nixos.org/channels/nixpkgs-unstable"
+                ]
+            ],
+            "modify_profile": true,
+            "daemon_user_count": 32,
+            "nix_build_group_name": "nixbld",
+            "nix_build_group_id": 3000,
+            "nix_build_user_prefix": "_nixbld",
+            "nix_build_user_id_base": 300,
+            "nix_package_url": "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-darwin.tar.xz",
+            "extra_conf": [],
+            "force": false
+        },
+        "encrypt": null,
+        "case_sensitive": false,
+        "volume_label": "Nix Store",
+        "root_disk": "disk1"
+    }
+}

--- a/tests/fixtures/linux/linux-multi.json
+++ b/tests/fixtures/linux/linux-multi.json
@@ -1,0 +1,589 @@
+{
+    "version": "0.0.0-unreleased",
+    "actions": [
+        {
+            "action": {
+                "action": "create_directory",
+                "path": "/nix",
+                "user": null,
+                "group": null,
+                "mode": 493,
+                "force_prune_on_revert": true
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "provision_nix",
+                "fetch_nix": {
+                    "action": {
+                        "url": "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz",
+                        "dest": "/nix/temp-install-dir"
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_users_and_group": {
+                    "action": {
+                        "daemon_user_count": 32,
+                        "nix_build_group_name": "nixbld",
+                        "nix_build_group_id": 3000,
+                        "nix_build_user_prefix": "nixbld",
+                        "nix_build_user_id_base": 3000,
+                        "create_group": {
+                            "action": {
+                                "name": "nixbld",
+                                "gid": 3000
+                            },
+                            "state": "Uncompleted"
+                        },
+                        "create_users": [
+                            {
+                                "action": {
+                                    "name": "nixbld0",
+                                    "uid": 3000,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld1",
+                                    "uid": 3001,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld2",
+                                    "uid": 3002,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld3",
+                                    "uid": 3003,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld4",
+                                    "uid": 3004,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld5",
+                                    "uid": 3005,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld6",
+                                    "uid": 3006,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld7",
+                                    "uid": 3007,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld8",
+                                    "uid": 3008,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld9",
+                                    "uid": 3009,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld10",
+                                    "uid": 3010,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld11",
+                                    "uid": 3011,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld12",
+                                    "uid": 3012,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld13",
+                                    "uid": 3013,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld14",
+                                    "uid": 3014,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld15",
+                                    "uid": 3015,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld16",
+                                    "uid": 3016,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld17",
+                                    "uid": 3017,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld18",
+                                    "uid": 3018,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld19",
+                                    "uid": 3019,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld20",
+                                    "uid": 3020,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld21",
+                                    "uid": 3021,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld22",
+                                    "uid": 3022,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld23",
+                                    "uid": 3023,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld24",
+                                    "uid": 3024,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld25",
+                                    "uid": 3025,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld26",
+                                    "uid": 3026,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld27",
+                                    "uid": 3027,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld28",
+                                    "uid": 3028,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld29",
+                                    "uid": 3029,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld30",
+                                    "uid": 3030,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld31",
+                                    "uid": 3031,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_nix_tree": {
+                    "action": {
+                        "create_directories": [
+                            {
+                                "action": {
+                                    "path": "/nix/var",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log/nix",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log/nix/drvs",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/db",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/gcroots",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/gcroots/per-user",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/profiles",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/profiles/per-user",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/temproots",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/userpool",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/daemon-socket",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "move_unpacked_nix": {
+                    "action": {
+                        "src": "/nix/temp-install-dir"
+                    },
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "configure_nix",
+                "setup_default_profile": {
+                    "action": {
+                        "channels": [
+                            "nixpkgs"
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "configure_shell_profile": {
+                    "action": {
+                        "create_or_append_files": [
+                            {
+                                "action": {
+                                    "path": "/etc/bash.bashrc",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 420,
+                                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n. '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n            \n"
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "place_channel_configuration": {
+                    "action": {
+                        "channels": [
+                            [
+                                "nixpkgs",
+                                "https://nixos.org/channels/nixpkgs-unstable"
+                            ]
+                        ],
+                        "create_file": {
+                            "action": {
+                                "path": "/root/.nix-channels",
+                                "user": null,
+                                "group": null,
+                                "mode": 436,
+                                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs",
+                                "force": false
+                            },
+                            "state": "Uncompleted"
+                        }
+                    },
+                    "state": "Uncompleted"
+                },
+                "place_nix_configuration": {
+                    "action": {
+                        "create_directory": {
+                            "action": {
+                                "path": "/etc/nix",
+                                "user": null,
+                                "group": null,
+                                "mode": 493,
+                                "force_prune_on_revert": false
+                            },
+                            "state": "Uncompleted"
+                        },
+                        "create_file": {
+                            "action": {
+                                "path": "/etc/nix/nix.conf",
+                                "user": null,
+                                "group": null,
+                                "mode": 436,
+                                "buf": "\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n",
+                                "force": false
+                            },
+                            "state": "Uncompleted"
+                        }
+                    },
+                    "state": "Uncompleted"
+                },
+                "configure_nix_daemon_service": {
+                    "action": {},
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "start_systemd_unit",
+                "unit": "nix-daemon.socket"
+            },
+            "state": "Uncompleted"
+        }
+    ],
+    "planner": {
+        "planner": "linux-multi",
+        "settings": {
+            "channels": [
+                [
+                    "nixpkgs",
+                    "https://nixos.org/channels/nixpkgs-unstable"
+                ]
+            ],
+            "modify_profile": true,
+            "daemon_user_count": 32,
+            "nix_build_group_name": "nixbld",
+            "nix_build_group_id": 3000,
+            "nix_build_user_prefix": "nixbld",
+            "nix_build_user_id_base": 3000,
+            "nix_package_url": "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz",
+            "extra_conf": [],
+            "force": false
+        }
+    }
+}

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,0 +1,633 @@
+{
+    "version": "0.0.0-unreleased",
+    "actions": [
+        {
+            "action": {
+                "action": "create_directory",
+                "path": "/home/nix",
+                "user": null,
+                "group": null,
+                "mode": 493,
+                "force_prune_on_revert": true
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "create_file",
+                "path": "/etc/systemd/system/nix-directory.service",
+                "user": null,
+                "group": null,
+                "mode": 420,
+                "buf": "\n            [Unit]\nDescription=Create a `/nix` directory to be used for bind mounting\nPropagatesStopTo=nix-daemon.service\nPropagatesStopTo=nix.mount\nDefaultDependencies=no\n\n[Service]\nType=oneshot\nExecCondition=sh -c \"if [ -d /nix ]; then exit 1; else exit 0; fi\"\n            ExecStart=steamos-readonly disable\nExecStart=mkdir -vp /nix\nExecStart=chmod -v 0755 /nix\nExecStart=chown -v root /nix\nExecStart=chgrp -v root /nix\nExecStart=steamos-readonly enable\nExecStop=steamos-readonly disable\nExecStop=rmdir /nix\nExecStop=steamos-readonly enable\nRemainAfterExit=true\n",
+                "force": false
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "create_file",
+                "path": "/etc/systemd/system/nix.mount",
+                "user": null,
+                "group": null,
+                "mode": 420,
+                "buf": "[Unit]\nDescription=Mount `/home/nix` on `/nix`\nPropagatesStopTo=nix-daemon.service\nPropagatesStopTo=nix-directory.service\nAfter=nix-directory.service\nRequires=nix-directory.service\nConditionPathIsDirectory=/nix\nDefaultDependencies=no\n\n[Mount]\nWhat=/home/nix\nWhere=/nix\nType=none\nDirectoryMode=0755\nOptions=bind\n",
+                "force": false
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "create_file",
+                "path": "/etc/systemd/system/ensure-symlinked-units-resolve.service",
+                "user": null,
+                "group": null,
+                "mode": 420,
+                "buf": "[Unit]\nDescription=Ensure Nix related units which are symlinked resolve\nAfter=nix.mount\nRequires=nix-directory.service\nRequires=nix.mount\nPropagatesStopTo=nix-directory.service\nPropagatesStopTo=nix.mount\nDefaultDependencies=no\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/systemctl daemon-reload\nExecStart=/usr/bin/systemctl restart --no-block sockets.target timers.target multi-user.target\n\n[Install]\nWantedBy=sysinit.target\n",
+                "force": false
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "start_systemd_unit",
+                "unit": "ensure-symlinked-units-resolve.service"
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "provision_nix",
+                "fetch_nix": {
+                    "action": {
+                        "url": "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz",
+                        "dest": "/nix/temp-install-dir"
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_users_and_group": {
+                    "action": {
+                        "daemon_user_count": 32,
+                        "nix_build_group_name": "nixbld",
+                        "nix_build_group_id": 3000,
+                        "nix_build_user_prefix": "nixbld",
+                        "nix_build_user_id_base": 3000,
+                        "create_group": {
+                            "action": {
+                                "name": "nixbld",
+                                "gid": 3000
+                            },
+                            "state": "Uncompleted"
+                        },
+                        "create_users": [
+                            {
+                                "action": {
+                                    "name": "nixbld0",
+                                    "uid": 3000,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld1",
+                                    "uid": 3001,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld2",
+                                    "uid": 3002,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld3",
+                                    "uid": 3003,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld4",
+                                    "uid": 3004,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld5",
+                                    "uid": 3005,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld6",
+                                    "uid": 3006,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld7",
+                                    "uid": 3007,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld8",
+                                    "uid": 3008,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld9",
+                                    "uid": 3009,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld10",
+                                    "uid": 3010,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld11",
+                                    "uid": 3011,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld12",
+                                    "uid": 3012,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld13",
+                                    "uid": 3013,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld14",
+                                    "uid": 3014,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld15",
+                                    "uid": 3015,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld16",
+                                    "uid": 3016,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld17",
+                                    "uid": 3017,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld18",
+                                    "uid": 3018,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld19",
+                                    "uid": 3019,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld20",
+                                    "uid": 3020,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld21",
+                                    "uid": 3021,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld22",
+                                    "uid": 3022,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld23",
+                                    "uid": 3023,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld24",
+                                    "uid": 3024,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld25",
+                                    "uid": 3025,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld26",
+                                    "uid": 3026,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld27",
+                                    "uid": 3027,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld28",
+                                    "uid": 3028,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld29",
+                                    "uid": 3029,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld30",
+                                    "uid": 3030,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "name": "nixbld31",
+                                    "uid": 3031,
+                                    "groupname": "nixbld",
+                                    "gid": 3000
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "create_nix_tree": {
+                    "action": {
+                        "create_directories": [
+                            {
+                                "action": {
+                                    "path": "/nix/var",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log/nix",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/log/nix/drvs",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/db",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/gcroots",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/gcroots/per-user",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/profiles",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/profiles/per-user",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/temproots",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/userpool",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            },
+                            {
+                                "action": {
+                                    "path": "/nix/var/nix/daemon-socket",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 493,
+                                    "force_prune_on_revert": false
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "move_unpacked_nix": {
+                    "action": {
+                        "src": "/nix/temp-install-dir"
+                    },
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "configure_nix",
+                "setup_default_profile": {
+                    "action": {
+                        "channels": [
+                            "nixpkgs"
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "configure_shell_profile": {
+                    "action": {
+                        "create_or_append_files": [
+                            {
+                                "action": {
+                                    "path": "/etc/bash.bashrc",
+                                    "user": null,
+                                    "group": null,
+                                    "mode": 420,
+                                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n. '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n            \n"
+                                },
+                                "state": "Uncompleted"
+                            }
+                        ]
+                    },
+                    "state": "Uncompleted"
+                },
+                "place_channel_configuration": {
+                    "action": {
+                        "channels": [
+                            [
+                                "nixpkgs",
+                                "https://nixos.org/channels/nixpkgs-unstable"
+                            ]
+                        ],
+                        "create_file": {
+                            "action": {
+                                "path": "/root/.nix-channels",
+                                "user": null,
+                                "group": null,
+                                "mode": 436,
+                                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs",
+                                "force": false
+                            },
+                            "state": "Uncompleted"
+                        }
+                    },
+                    "state": "Uncompleted"
+                },
+                "place_nix_configuration": {
+                    "action": {
+                        "create_directory": {
+                            "action": {
+                                "path": "/etc/nix",
+                                "user": null,
+                                "group": null,
+                                "mode": 493,
+                                "force_prune_on_revert": false
+                            },
+                            "state": "Uncompleted"
+                        },
+                        "create_file": {
+                            "action": {
+                                "path": "/etc/nix/nix.conf",
+                                "user": null,
+                                "group": null,
+                                "mode": 436,
+                                "buf": "\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n",
+                                "force": false
+                            },
+                            "state": "Uncompleted"
+                        }
+                    },
+                    "state": "Uncompleted"
+                },
+                "configure_nix_daemon_service": {
+                    "action": {},
+                    "state": "Uncompleted"
+                }
+            },
+            "state": "Uncompleted"
+        },
+        {
+            "action": {
+                "action": "start_systemd_unit",
+                "unit": "nix-daemon.socket"
+            },
+            "state": "Uncompleted"
+        }
+    ],
+    "planner": {
+        "planner": "steam-deck",
+        "persistence": "/home/nix",
+        "settings": {
+            "channels": [
+                [
+                    "nixpkgs",
+                    "https://nixos.org/channels/nixpkgs-unstable"
+                ]
+            ],
+            "modify_profile": true,
+            "daemon_user_count": 32,
+            "nix_build_group_name": "nixbld",
+            "nix_build_group_id": 3000,
+            "nix_build_user_prefix": "nixbld",
+            "nix_build_user_id_base": 3000,
+            "nix_package_url": "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz",
+            "extra_conf": [],
+            "force": false
+        }
+    }
+}

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -1,0 +1,29 @@
+use harmonic::InstallPlan;
+
+const LINUX_MULTI: &str = include_str!("./fixtures/linux/linux-multi.json");
+const STEAM_DECK: &str = include_str!("./fixtures/linux/steam-deck.json");
+const DARWIN_MULTI: &str = include_str!("./fixtures/darwin/darwin-multi.json");
+
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, it's time to raise version.
+#[test]
+fn plan_compat_linux_multi() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(LINUX_MULTI)?;
+    Ok(())
+}
+
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, it's time to raise version.
+#[test]
+fn plan_compat_steam_deck() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
+    Ok(())
+}
+
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, it's time to raise version.
+#[test]
+fn plan_compat_darwin_multi() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(DARWIN_MULTI)?;
+    Ok(())
+}


### PR DESCRIPTION
Add some compatability tests.

Here's an example of the error when we try to parse a plan from a future version:

```rust
     Running tests/integration.rs (target/debug/deps/integration-34d3d284b1eb3142)

running 3 tests
Error: This version of Harmonic (0.0.0-unreleased) is not compatible with this plan's version (0.0.1-unreleased), please use a compatible version (according to Semantic Versioning) at line 2 column 33

Location:
    tests/plans/mod.rs:21:26
test plans::plan_parses_darwin_multi ... FAILED
test plans::plan_parses_linux_multi ... ok
test plans::plan_parses_steam_deck ... ok

failures:

---- plans::plan_parses_darwin_multi stdout ----
thread 'plans::plan_parses_darwin_multi' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/897e37553bba8b42751c67658967889d11ecd120/library/test/src/lib.rs:184:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```