### PR TITLE
Planner explain output fix

### DIFF
--- a/src/action/stateful.rs
+++ b/src/action/stateful.rs
@@ -26,7 +26,7 @@ impl StatefulAction<Box<dyn Action>> {
     /// A description of what this action would do during execution
     pub fn describe_execute(&self) -> Vec<ActionDescription> {
         match self.state {
-            ActionState::Uncompleted | ActionState::Skipped => {
+            ActionState::Completed | ActionState::Skipped => {
                 vec![]
             },
             _ => self.action.execute_description(),
@@ -35,7 +35,7 @@ impl StatefulAction<Box<dyn Action>> {
     /// A description of what this action would do during revert
     pub fn describe_revert(&self) -> Vec<ActionDescription> {
         match self.state {
-            ActionState::Completed | ActionState::Skipped => {
+            ActionState::Uncompleted | ActionState::Skipped => {
                 vec![]
             },
             _ => self.action.revert_description(),


### PR DESCRIPTION
Fixes the planner output being empty:

```
Nix install plan (v0.0.0-unreleased)

Planner: linux-multi

Planner settings:

* daemon_user_count: 32
* channels: ["nixpkgs=https://nixos.org/channels/nixpkgs-unstable"]
* nix_build_group_id: 3000
* extra_conf: []
* nix_package_url: "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz"
* nix_build_user_prefix: "nixbld"
* nix_build_user_id_base: 3000
* nix_build_group_name: "nixbld"
* modify_profile: true
* force: false

The following actions will be taken (`--explain` for more context):




Proceed? (y/N): ^C
```

Is back to

```
Nix install plan (v0.0.0-unreleased)

Planner: linux-multi

Planner settings:

* nix_build_user_id_base: 3000
* force: false
* nix_build_group_name: "nixbld"
* modify_profile: true
* channels: ["nixpkgs=https://nixos.org/channels/nixpkgs-unstable"]
* nix_build_user_prefix: "nixbld"
* extra_conf: []
* daemon_user_count: 32
* nix_package_url: "https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz"
* nix_build_group_id: 3000

The following actions will be taken (`--explain` for more context):

* Create directory `/nix`
* Fetch `https://releases.nixos.org/nix/nix-2.11.0/nix-2.11.0-x86_64-linux.tar.xz` to `/nix/temp-install-dir`
* Create build users (UID 3000-3032) and group (GID 3000)
* Create a directory tree in `/nix`
* Move the downloaded Nix into `/nix`
* Setup the default Nix profile
* Configure Nix daemon related settings with systemd
* Place the nix configuration in `/etc/nix/nix.conf`
* Place channel configuration at `/root/.nix-channels`
* Configure the shell profiles
* Enable (and start) the systemd unit nix-daemon.socket


Proceed? (y/N): ^C

```
