### PR TITLE
More portable EUID check

### DIFF
--- a/nix-install.sh
+++ b/nix-install.sh
@@ -94,7 +94,7 @@ main() {
     fi
 
     local maybe_sudo=""
-    if [ "$EUID" -ne 0 ] && command -v sudo > /dev/null; then
+    if [ "$(id -u)" -ne 0 ] && command -v sudo > /dev/null; then
         maybe_sudo="sudo"
     fi
 


### PR DESCRIPTION
@lucperkins reported that `$EUID` may not be set on some shells so we now do it differently.