### PR TITLE
Tidy UX, make --logger param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,8 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1.21.0", features = ["time", "io-std", "process", "fs", "si
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = { version = "0.1.36", features = [ "valuable" ] }
 tracing-error = { version = "0.2.0", optional = true }
-tracing-subscriber = { version = "0.3.15", features = [ "env-filter", "valuable" ], optional = true }
+tracing-subscriber = { version = "0.3.15", features = [ "json", "env-filter", "valuable" ], optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 valuable = { version = "0.1.0", features = ["derive"] }
 walkdir = "2.3.2"

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -23,7 +23,7 @@ pub struct CreateDirectory {
 }
 
 impl CreateDirectory {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         path: impl AsRef<Path>,
         user: impl Into<Option<String>>,
@@ -78,7 +78,7 @@ impl Action for CreateDirectory {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
         user = self.user,
         group = self.group,
@@ -150,7 +150,7 @@ impl Action for CreateDirectory {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
         user = self.user,
         group = self.group,

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -25,7 +25,7 @@ pub struct CreateFile {
 }
 
 impl CreateFile {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         path: impl AsRef<Path>,
         user: impl Into<Option<String>>,
@@ -62,7 +62,7 @@ impl Action for CreateFile {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
         user = self.user,
         group = self.group,
@@ -135,7 +135,7 @@ impl Action for CreateFile {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
         user = self.user,
         group = self.group,

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -15,7 +15,7 @@ pub struct CreateGroup {
 }
 
 impl CreateGroup {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn plan(name: String, gid: usize) -> StatefulAction<Self> {
         Self { name, gid }.into()
     }
@@ -37,7 +37,7 @@ impl Action for CreateGroup {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         user = self.name,
         gid = self.gid,
     ))]
@@ -107,7 +107,7 @@ impl Action for CreateGroup {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         user = self.name,
         gid = self.gid,
     ))]

--- a/src/action/base/create_or_append_file.rs
+++ b/src/action/base/create_or_append_file.rs
@@ -30,7 +30,7 @@ pub struct CreateOrAppendFile {
 }
 
 impl CreateOrAppendFile {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         path: impl AsRef<Path>,
         user: impl Into<Option<String>>,
@@ -62,7 +62,7 @@ impl Action for CreateOrAppendFile {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
         user = self.user,
         group = self.group,
@@ -142,7 +142,7 @@ impl Action for CreateOrAppendFile {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
         user = self.user,
         group = self.group,

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -17,7 +17,7 @@ pub struct CreateUser {
 }
 
 impl CreateUser {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn plan(name: String, uid: usize, groupname: String, gid: usize) -> StatefulAction<Self> {
         Self {
             name,
@@ -47,7 +47,7 @@ impl Action for CreateUser {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         user = self.name,
         uid = self.uid,
         groupname = self.groupname,
@@ -231,7 +231,7 @@ impl Action for CreateUser {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         user = self.name,
         uid = self.uid,
         gid = self.gid,

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -15,7 +15,7 @@ pub struct FetchAndUnpackNix {
 }
 
 impl FetchAndUnpackNix {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(url: Url, dest: PathBuf) -> Result<StatefulAction<Self>, ActionError> {
         // TODO(@hoverbear): Check URL exists?
         // TODO(@hoverbear): Check tempdir exists
@@ -35,7 +35,7 @@ impl Action for FetchAndUnpackNix {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         url = %self.url,
         dest = %self.dest.display(),
     ))]
@@ -66,7 +66,7 @@ impl Action for FetchAndUnpackNix {
         vec![/* Deliberately empty -- this is a noop */]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         url = %self.url,
         dest = %self.dest.display(),
     ))]

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -13,7 +13,7 @@ pub struct MoveUnpackedNix {
 }
 
 impl MoveUnpackedNix {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(src: PathBuf) -> Result<StatefulAction<Self>, ActionError> {
         // Note: Do NOT try to check for the src/dest since the installer creates those
         Ok(Self { src }.into())
@@ -37,7 +37,7 @@ impl Action for MoveUnpackedNix {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         src = %self.src.display(),
         dest = DEST,
     ))]
@@ -73,7 +73,7 @@ impl Action for MoveUnpackedNix {
         vec![/* Deliberately empty -- this is a noop */]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         src = %self.src.display(),
         dest = DEST,
     ))]

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -18,7 +18,7 @@ pub struct SetupDefaultProfile {
 }
 
 impl SetupDefaultProfile {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(channels: Vec<String>) -> Result<StatefulAction<Self>, ActionError> {
         Ok(Self { channels }.into())
     }
@@ -35,7 +35,7 @@ impl Action for SetupDefaultProfile {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         channels = %self.channels.join(","),
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -156,7 +156,7 @@ impl Action for SetupDefaultProfile {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         channels = %self.channels.join(","),
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -24,7 +24,7 @@ pub struct ConfigureNix {
 }
 
 impl ConfigureNix {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(settings: &CommonSettings) -> Result<StatefulAction<Self>, ActionError> {
         let channels: Vec<(String, Url)> = settings
             .channels
@@ -87,7 +87,7 @@ impl Action for ConfigureNix {
         buf
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             setup_default_profile,
@@ -137,7 +137,7 @@ impl Action for ConfigureNix {
         buf
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             setup_default_profile,

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -39,7 +39,7 @@ pub struct ConfigureShellProfile {
 }
 
 impl ConfigureShellProfile {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
         let mut create_or_append_files = Vec::default();
         let mut create_directories = Vec::default();
@@ -148,7 +148,7 @@ impl Action for ConfigureShellProfile {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             create_or_append_files,
@@ -200,7 +200,7 @@ impl Action for ConfigureShellProfile {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             create_directories,

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -26,7 +26,7 @@ pub struct CreateNixTree {
 }
 
 impl CreateNixTree {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
         let mut create_directories = Vec::default();
         for path in PATHS {
@@ -64,7 +64,7 @@ impl Action for CreateNixTree {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { create_directories } = self;
 
@@ -96,7 +96,7 @@ impl Action for CreateNixTree {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { create_directories } = self;
 

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -19,7 +19,7 @@ pub struct CreateUsersAndGroups {
 }
 
 impl CreateUsersAndGroups {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(settings: CommonSettings) -> Result<StatefulAction<Self>, ActionError> {
         // TODO(@hoverbear): CHeck if it exist, error if so
         let create_group = CreateGroup::plan(
@@ -91,7 +91,7 @@ impl Action for CreateUsersAndGroups {
         vec![ActionDescription::new(self.tracing_synopsis(), explanation)]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         daemon_user_count = self.daemon_user_count,
         nix_build_group_name = self.nix_build_group_name,
         nix_build_group_id = self.nix_build_group_id,
@@ -188,7 +188,7 @@ impl Action for CreateUsersAndGroups {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         daemon_user_count = self.daemon_user_count,
         nix_build_group_name = self.nix_build_group_name,
         nix_build_group_id = self.nix_build_group_id,

--- a/src/action/common/place_channel_configuration.rs
+++ b/src/action/common/place_channel_configuration.rs
@@ -13,7 +13,7 @@ pub struct PlaceChannelConfiguration {
 }
 
 impl PlaceChannelConfiguration {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         channels: Vec<(String, Url)>,
         force: bool,
@@ -58,7 +58,7 @@ impl Action for PlaceChannelConfiguration {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         channels = self.channels.iter().map(|(c, u)| format!("{c}={u}")).collect::<Vec<_>>().join(", "),
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -82,7 +82,7 @@ impl Action for PlaceChannelConfiguration {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         channels = self.channels.iter().map(|(c, u)| format!("{c}={u}")).collect::<Vec<_>>().join(", "),
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -14,7 +14,7 @@ pub struct PlaceNixConfiguration {
 }
 
 impl PlaceNixConfiguration {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         nix_build_group_name: String,
         extra_conf: Vec<String>,
@@ -60,7 +60,7 @@ impl Action for PlaceNixConfiguration {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             create_file,
@@ -83,7 +83,7 @@ impl Action for PlaceNixConfiguration {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             create_file,

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -20,7 +20,7 @@ pub struct ProvisionNix {
 }
 
 impl ProvisionNix {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(settings: &CommonSettings) -> Result<StatefulAction<Self>, ActionError> {
         let fetch_nix = FetchAndUnpackNix::plan(
             settings.nix_package_url.clone(),
@@ -65,7 +65,7 @@ impl Action for ProvisionNix {
         buf
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             fetch_nix,
@@ -106,7 +106,7 @@ impl Action for ProvisionNix {
         buf
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             fetch_nix,

--- a/src/action/darwin/bootstrap_apfs_volume.rs
+++ b/src/action/darwin/bootstrap_apfs_volume.rs
@@ -16,7 +16,7 @@ pub struct BootstrapApfsVolume {
 }
 
 impl BootstrapApfsVolume {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(path: impl AsRef<Path>) -> Result<StatefulAction<Self>, ActionError> {
         Ok(Self {
             path: path.as_ref().to_path_buf(),
@@ -36,7 +36,7 @@ impl Action for BootstrapApfsVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -70,7 +70,7 @@ impl Action for BootstrapApfsVolume {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/darwin/create_apfs_volume.rs
+++ b/src/action/darwin/create_apfs_volume.rs
@@ -15,7 +15,7 @@ pub struct CreateApfsVolume {
 }
 
 impl CreateApfsVolume {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         disk: impl AsRef<Path>,
         name: String,
@@ -45,7 +45,7 @@ impl Action for CreateApfsVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
         name = %self.name,
         case_sensitive = %self.case_sensitive,
@@ -91,7 +91,7 @@ impl Action for CreateApfsVolume {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
         name = %self.name,
         case_sensitive = %self.case_sensitive,

--- a/src/action/darwin/create_nix_volume.rs
+++ b/src/action/darwin/create_nix_volume.rs
@@ -33,7 +33,7 @@ pub struct CreateNixVolume {
 }
 
 impl CreateNixVolume {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         disk: impl AsRef<Path>,
         name: String,
@@ -150,7 +150,7 @@ impl Action for CreateNixVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(destination,))]
+    #[tracing::instrument(level = "debug", skip_all, fields(destination,))]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             disk: _,
@@ -213,7 +213,7 @@ impl Action for CreateNixVolume {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(disk, name))]
+    #[tracing::instrument(level = "debug", skip_all, fields(disk, name))]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             disk: _,

--- a/src/action/darwin/create_synthetic_objects.rs
+++ b/src/action/darwin/create_synthetic_objects.rs
@@ -9,7 +9,7 @@ use crate::action::{Action, ActionDescription, ActionError, StatefulAction};
 pub struct CreateSyntheticObjects;
 
 impl CreateSyntheticObjects {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
         Ok(Self.into())
     }
@@ -29,7 +29,7 @@ impl Action for CreateSyntheticObjects {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all, fields())]
     async fn execute(&mut self) -> Result<(), ActionError> {
         // Yup we literally call both and ignore the error! Reasoning: https://github.com/NixOS/nix/blob/95331cb9c99151cbd790ceb6ddaf49fc1c0da4b3/scripts/create-darwin-volume.sh#L261
         execute_command(
@@ -59,7 +59,7 @@ impl Action for CreateSyntheticObjects {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all, fields())]
     async fn revert(&mut self) -> Result<(), ActionError> {
         // Yup we literally call both and ignore the error! Reasoning: https://github.com/NixOS/nix/blob/95331cb9c99151cbd790ceb6ddaf49fc1c0da4b3/scripts/create-darwin-volume.sh#L261
         execute_command(

--- a/src/action/darwin/enable_ownership.rs
+++ b/src/action/darwin/enable_ownership.rs
@@ -18,7 +18,7 @@ pub struct EnableOwnership {
 }
 
 impl EnableOwnership {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(path: impl AsRef<Path>) -> Result<StatefulAction<Self>, ActionError> {
         Ok(Self {
             path: path.as_ref().to_path_buf(),
@@ -38,7 +38,7 @@ impl Action for EnableOwnership {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -79,7 +79,7 @@ impl Action for EnableOwnership {
         vec![]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         path = %self.path.display(),
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/darwin/encrypt_apfs_volume.rs
+++ b/src/action/darwin/encrypt_apfs_volume.rs
@@ -18,7 +18,7 @@ pub struct EncryptApfsVolume {
 }
 
 impl EncryptApfsVolume {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         disk: impl AsRef<Path>,
         name: impl AsRef<str>,
@@ -47,7 +47,7 @@ impl Action for EncryptApfsVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -142,7 +142,7 @@ impl Action for EncryptApfsVolume {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/darwin/kickstart_launchctl_service.rs
+++ b/src/action/darwin/kickstart_launchctl_service.rs
@@ -14,7 +14,7 @@ pub struct KickstartLaunchctlService {
 }
 
 impl KickstartLaunchctlService {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(unit: String) -> Result<StatefulAction<Self>, ActionError> {
         Ok(Self { unit }.into())
     }
@@ -32,7 +32,7 @@ impl Action for KickstartLaunchctlService {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         unit = %self.unit,
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -56,7 +56,7 @@ impl Action for KickstartLaunchctlService {
         vec![]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         unit = %self.unit,
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/darwin/unmount_apfs_volume.rs
+++ b/src/action/darwin/unmount_apfs_volume.rs
@@ -17,7 +17,7 @@ pub struct UnmountApfsVolume {
 }
 
 impl UnmountApfsVolume {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         disk: impl AsRef<Path>,
         name: String,
@@ -38,7 +38,7 @@ impl Action for UnmountApfsVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
         name = %self.name,
     ))]
@@ -62,7 +62,7 @@ impl Action for UnmountApfsVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
         name = %self.name,
     ))]

--- a/src/action/linux/configure_nix_daemon_service.rs
+++ b/src/action/linux/configure_nix_daemon_service.rs
@@ -22,7 +22,7 @@ Run systemd utilities to configure the Nix daemon
 pub struct ConfigureNixDaemonService {}
 
 impl ConfigureNixDaemonService {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
         match OperatingSystem::host() {
             OperatingSystem::MacOSX {
@@ -62,7 +62,7 @@ impl Action for ConfigureNixDaemonService {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {} = self;
 
@@ -172,7 +172,7 @@ impl Action for ConfigureNixDaemonService {
         )]
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         match OperatingSystem::host() {
             OperatingSystem::MacOSX {

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -14,7 +14,7 @@ pub struct StartSystemdUnit {
 }
 
 impl StartSystemdUnit {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(unit: impl AsRef<str>) -> Result<StatefulAction<Self>, ActionError> {
         Ok(StatefulAction {
             action: Self {
@@ -36,7 +36,7 @@ impl Action for StartSystemdUnit {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         unit = %self.unit,
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -64,7 +64,7 @@ impl Action for StartSystemdUnit {
         )]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         unit = %self.unit,
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -57,7 +57,7 @@ pub struct MyAction {}
 
 
 impl MyAction {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
         Ok(Self {}.into())
     }
@@ -75,7 +75,7 @@ impl Action for MyAction {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         // Tracing fields...
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
@@ -87,7 +87,7 @@ impl Action for MyAction {
          vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(skip_all, fields(
+    #[tracing::instrument(level = "debug", skip_all, fields(
         // Tracing fields...
     ))]
     async fn revert(&mut self) -> Result<(), ActionError> {

--- a/src/action/stateful.rs
+++ b/src/action/stateful.rs
@@ -23,6 +23,9 @@ where
 }
 
 impl StatefulAction<Box<dyn Action>> {
+    pub fn tracing_synopsis(&self) -> String {
+        self.action.tracing_synopsis()
+    }
     /// A description of what this action would do during execution
     pub fn describe_execute(&self) -> Vec<ActionDescription> {
         match self.state {
@@ -99,6 +102,10 @@ impl<A> StatefulAction<A>
 where
     A: Action,
 {
+    pub fn tracing_synopsis(&self) -> String {
+        self.action.tracing_synopsis()
+    }
+
     pub fn inner(&self) -> &A {
         &self.action
     }

--- a/src/cli/arg/instrumentation.rs
+++ b/src/cli/arg/instrumentation.rs
@@ -5,11 +5,35 @@ use tracing_error::ErrorLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use valuable::Valuable;
 
+#[derive(Clone, Default, Debug, clap::ValueEnum, Valuable)]
+pub enum Logger {
+    #[default]
+    Compact,
+    Full,
+    Pretty,
+    Json,
+}
+
+impl std::fmt::Display for Logger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let logger = match self {
+            Logger::Compact => "compact",
+            Logger::Full => "full",
+            Logger::Pretty => "pretty",
+            Logger::Json => "json",
+        };
+        write!(f, "{}", logger)
+    }
+}
+
 #[derive(clap::Args, Debug, Valuable)]
 pub struct Instrumentation {
     /// Enable debug logs, -vv for trace
     #[clap(short = 'v', long, action = clap::ArgAction::Count, global = true)]
     pub verbose: u8,
+    /// Which logger to use
+    #[clap(long, default_value_t = Default::default(), global = true)]
+    pub logger: Logger,
 }
 
 impl<'a> Instrumentation {
@@ -23,19 +47,44 @@ impl<'a> Instrumentation {
     }
 
     pub fn setup<'b: 'a>(&'b self) -> eyre::Result<()> {
-        let fmt_layer = self.fmt_layer();
         let filter_layer = self.filter_layer()?;
 
-        tracing_subscriber::registry()
+        let registry = tracing_subscriber::registry()
             .with(filter_layer)
-            .with(fmt_layer)
-            .with(ErrorLayer::default())
-            .try_init()?;
+            .with(ErrorLayer::default());
+
+        match self.logger {
+            Logger::Compact => {
+                let fmt_layer = self.fmt_layer_compact();
+                registry.with(fmt_layer).try_init()?
+            },
+            Logger::Full => {
+                let fmt_layer = self.fmt_layer_full();
+                registry.with(fmt_layer).try_init()?
+            },
+            Logger::Pretty => {
+                let fmt_layer = self.fmt_layer_pretty();
+                registry.with(fmt_layer).try_init()?
+            },
+            Logger::Json => {
+                let fmt_layer = self.fmt_layer_json();
+                registry.with(fmt_layer).try_init()?
+            },
+        }
 
         Ok(())
     }
 
-    pub fn fmt_layer<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    pub fn fmt_layer_full<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::Layer::new()
+            .with_ansi(atty::is(Stream::Stderr))
+            .with_writer(std::io::stderr)
+    }
+
+    pub fn fmt_layer_pretty<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
     where
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
@@ -43,6 +92,32 @@ impl<'a> Instrumentation {
             .with_ansi(atty::is(Stream::Stderr))
             .with_writer(std::io::stderr)
             .pretty()
+    }
+
+    pub fn fmt_layer_json<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::Layer::new()
+            .with_ansi(atty::is(Stream::Stderr))
+            .with_writer(std::io::stderr)
+            .json()
+    }
+
+    pub fn fmt_layer_compact<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::Layer::new()
+            .with_ansi(atty::is(Stream::Stderr))
+            .with_writer(std::io::stderr)
+            .compact()
+            .without_time()
+            .with_target(false)
+            .with_thread_ids(false)
+            .with_thread_names(false)
+            .with_file(false)
+            .with_line_number(false)
     }
 
     pub fn filter_layer(&self) -> eyre::Result<EnvFilter> {

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -1,8 +1,6 @@
 use std::io::{stdin, stdout, BufRead, Write};
 
-use crossterm::event::{EventStream, KeyCode};
 use eyre::{eyre, WrapErr};
-use futures::{FutureExt, StreamExt};
 use owo_colors::OwoColorize;
 
 // Do not try to get clever!

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,7 @@ pub struct HarmonicCli {
 
 #[async_trait::async_trait]
 impl CommandExecute for HarmonicCli {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             instrumentation: _,

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -44,7 +44,7 @@ pub struct Install {
 
 #[async_trait::async_trait]
 impl CommandExecute for Install {
-    #[tracing::instrument(skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all, fields())]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             no_confirm,

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -18,7 +18,7 @@ pub struct Plan {
 
 #[async_trait::async_trait]
 impl CommandExecute for Plan {
-    #[tracing::instrument(skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all, fields())]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self { planner, output } = self;
 

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use clap::{ArgAction, Parser};
 use eyre::{eyre, WrapErr};
+use owo_colors::OwoColorize;
 use rand::Rng;
 
 use crate::cli::{interaction, CommandExecute};
@@ -38,7 +39,7 @@ pub struct Uninstall {
 
 #[async_trait::async_trait]
 impl CommandExecute for Uninstall {
-    #[tracing::instrument(skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all, fields())]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             no_confirm,
@@ -114,6 +115,13 @@ impl CommandExecute for Uninstall {
         plan.uninstall(rx).await?;
         // TODO(@hoverbear): It would be so nice to catch errors and offer the user a way to keep going...
         //                   However that will require being able to link error -> step and manually setting that step as `Uncompleted`.
+
+        println!(
+            "\
+            {success}\n\
+            ",
+            success = "Nix was uninstalled successfully!".green().bold(),
+        );
 
         Ok(ExitCode::SUCCESS)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ use planner::BuiltinPlanner;
 
 use tokio::process::Command;
 
-#[tracing::instrument(skip_all, fields(command = %format!("{:?}", command.as_std())))]
+#[tracing::instrument(level = "debug", skip_all, fields(command = %format!("{:?}", command.as_std())))]
 async fn execute_command(command: &mut Command) -> Result<Output, std::io::Error> {
     let command_str = format!("{:?}", command.as_std());
     tracing::trace!("Executing `{command_str}`");
@@ -104,7 +104,7 @@ async fn execute_command(command: &mut Command) -> Result<Output, std::io::Error
     }
 }
 
-#[tracing::instrument(skip_all, fields(
+#[tracing::instrument(level = "debug", skip_all, fields(
     k = %k.as_ref().to_string_lossy(),
     v = %v.as_ref().to_string_lossy(),
 ))]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -49,7 +49,7 @@ impl InstallPlan {
             version: current_version()?,
         })
     }
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn describe_install(&self, explain: bool) -> Result<String, HarmonicError> {
         let Self {
             planner,
@@ -107,7 +107,7 @@ impl InstallPlan {
         Ok(buf)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn install(
         &mut self,
         cancel_channel: impl Into<Option<Receiver<()>>>,
@@ -134,6 +134,7 @@ impl InstallPlan {
                 }
             }
 
+            tracing::info!("Step: {}", action.tracing_synopsis());
             if let Err(err) = action.try_execute().await {
                 if let Err(err) = write_receipt(self.clone()).await {
                     tracing::error!("Error saving receipt: {:?}", err);
@@ -149,7 +150,7 @@ impl InstallPlan {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn describe_uninstall(&self, explain: bool) -> Result<String, HarmonicError> {
         let Self {
             version: _,
@@ -208,7 +209,7 @@ impl InstallPlan {
         Ok(buf)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn uninstall(
         &mut self,
         cancel_channel: impl Into<Option<Receiver<()>>>,
@@ -235,6 +236,7 @@ impl InstallPlan {
                 }
             }
 
+            tracing::info!("Step: {}", action.tracing_synopsis());
             if let Err(err) = action.try_revert().await {
                 if let Err(err) = write_receipt(self.clone()).await {
                     tracing::error!("Error saving receipt: {:?}", err);
@@ -286,7 +288,7 @@ fn ensure_version<'de, D: Deserializer<'de>>(d: D) -> Result<Version, D::Error> 
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(level = "debug")]
 async fn copy_self_to_nix_store() -> Result<(), std::io::Error> {
     let path = std::env::current_exe()?;
     tokio::fs::copy(path, "/nix/harmonic").await?;


### PR DESCRIPTION
Was talking with @grahamc about the UX and this fell out.

Some reasoning:

* We don't want to violate the library/binary boundary, so having the library blindly write to stderr etc is out of the question
* We don't really want to have the user pass a writer in
* Considered reworking the `install()` process to be like a stream/iter and have the binary able to do the printlns as it wanted. Still an option.
* Hooking into existing tracing support was a bonus

With default args (`--logger compact`):

![image](https://user-images.githubusercontent.com/130903/206770482-ccb43279-38a7-4a7d-8176-ed1c6096a655.png)


With `--logger full`:

![image](https://user-images.githubusercontent.com/130903/206770150-439a3436-3045-489d-9465-ef5c9efcf42e.png)


With `--logger pretty`:

![image](https://user-images.githubusercontent.com/130903/206770076-bcc64cb3-e366-40fa-83c6-b16742333007.png)


With `--logger json`:

![image](https://user-images.githubusercontent.com/130903/206770561-e0f99c89-913c-49df-b277-2b13dd847070.png)


