### PR TITLE
Better uninstall version error

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -283,7 +283,7 @@ fn ensure_version<'de, D: Deserializer<'de>>(d: D) -> Result<Version, D::Error> 
         Ok(plan_version)
     } else {
         Err(D::Error::custom(&format!(
-            "This version of Harmonic ({harmonic_version}) is not compatible with this plan's version ({plan_version}), please use a compatible version (according to Semantic Versioning)",
+            "This version of Harmonic ({harmonic_version}) is not compatible with this plan's version ({plan_version}), please use the binary stored for later uninstall at `/nix/harmonic` or a compatible version",
         )))
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -283,7 +283,7 @@ fn ensure_version<'de, D: Deserializer<'de>>(d: D) -> Result<Version, D::Error> 
         Ok(plan_version)
     } else {
         Err(D::Error::custom(&format!(
-            "This version of Harmonic ({harmonic_version}) is not compatible with this plan's version ({plan_version}), please use the binary stored for later uninstall at `/nix/harmonic` or a compatible version",
+            "This version of Harmonic ({harmonic_version}) is not compatible with this plan's version ({plan_version}), check for a compatible version at `/nix/harmonic` or download the matching release from https://github.com/DeterminateSystems/harmonic/releases",
         )))
     }
 }


### PR DESCRIPTION
Ensure that a user gets a useful error message if they try to uninstall with an incompatible version, as that sounds really frustrating.