### PR TITLE
Allow expected errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,7 @@ jobs:
       - name: Initial install
         run: sudo GITHUB_PATH=$GITHUB_PATH PATH=$PATH:$HOME/bin RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic install steam-deck --persistence `pwd`/ci-test-nix --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" --no-confirm
       - name: Initial uninstall (without a `nix run` first)
-        run: |
-          cp /nix/harmonic ./harmonic # Since /nix is a mount we must avoid requiring it to remain existing
-          sudo GITHUB_PATH=$GITHUB_PATH PATH=$PATH:$HOME/bin RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic uninstall --no-confirm
+        run: sudo GITHUB_PATH=$GITHUB_PATH PATH=$PATH:$HOME/bin RUST_LOG=harmonic=trace RUST_BACKTRACE=full /nix/harmonic uninstall --no-confirm
       - name: Repeated install
         run: sudo GITHUB_PATH=$GITHUB_PATH PATH=$PATH:$HOME/bin RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic install steam-deck --persistence `pwd`/ci-test-nix --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" --no-confirm
       - name: echo $PATH
@@ -150,9 +148,7 @@ jobs:
       #   if: success() || failure()
       #   shell: fish --login {0}
       - name: Repeated uninstall
-        run: |
-          cp /nix/harmonic ./harmonic # Since /nix is a mount we must avoid requiring it to remain existing
-          sudo GITHUB_PATH=$GITHUB_PATH PATH=$PATH:$HOME/bin RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic uninstall --no-confirm
+        run: sudo GITHUB_PATH=$GITHUB_PATH PATH=$PATH:$HOME/bin RUST_LOG=harmonic=trace RUST_BACKTRACE=full /nix/harmonic uninstall --no-confirm
 
   build-x86_64-darwin:
     name: Build x86_64 Darwin
@@ -187,9 +183,7 @@ jobs:
       - name: Initial install
         run: sudo GITHUB_PATH=$GITHUB_PATH RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic install darwin-multi --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" --no-confirm
       - name: Initial uninstall (without a `nix run` first)
-        run: |
-          cp /nix/harmonic ./harmonic # Since /nix is a mount we must avoid requiring it to remain existing
-          sudo GITHUB_PATH=$GITHUB_PATH RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic uninstall --no-confirm
+        run: sudo GITHUB_PATH=$GITHUB_PATH RUST_LOG=harmonic=trace RUST_BACKTRACE=full /nix/harmonic uninstall --no-confirm
       - name: Repeated install
         run: sudo GITHUB_PATH=$GITHUB_PATH RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic install darwin-multi --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}" --no-confirm
       - name: echo $PATH
@@ -214,7 +208,5 @@ jobs:
         if: success() || failure()
         shell: fish --login {0}
       - name: Repeated uninstall
-        run: |
-          cp /nix/harmonic ./harmonic # Since /nix is a mount we must avoid requiring it to remain existing
-          sudo GITHUB_PATH=$GITHUB_PATH RUST_LOG=harmonic=trace RUST_BACKTRACE=full ./harmonic uninstall --no-confirm
+        run: sudo GITHUB_PATH=$GITHUB_PATH RUST_LOG=harmonic=trace RUST_BACKTRACE=full /nix/harmonic uninstall --no-confirm
         

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -160,6 +160,8 @@ pub use stateful::{ActionState, StatefulAction};
 use std::error::Error;
 use tokio::task::JoinError;
 
+use crate::error::HasExpectedErrors;
+
 /// An action which can be reverted or completed, with an action state
 ///
 /// This trait interacts with [`StatefulAction`] which does the [`ActionState`] manipulation and provides some tracing facilities.
@@ -307,4 +309,10 @@ pub enum ActionError {
         #[from]
         std::string::FromUtf8Error,
     ),
+}
+
+impl HasExpectedErrors for ActionError {
+    fn expected(&self) -> bool {
+        false
+    }
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -312,7 +312,7 @@ pub enum ActionError {
 }
 
 impl HasExpectedErrors for ActionError {
-    fn expected(&self) -> bool {
-        false
+    fn expected(&self) -> Option<Box<dyn std::error::Error>> {
+        None
     }
 }

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -6,9 +6,10 @@ use std::{
 use crate::{
     action::ActionState,
     cli::{ensure_root, interaction, signal_channel, CommandExecute},
+    error::HasExpectedErrors,
     plan::RECEIPT_LOCATION,
     planner::Planner,
-    BuiltinPlanner, InstallPlan, error::HasExpectedErrors,
+    BuiltinPlanner, InstallPlan,
 };
 use clap::{ArgAction, Parser};
 use eyre::{eyre, WrapErr};
@@ -106,7 +107,7 @@ impl CommandExecute for Install {
                             return Ok(ExitCode::FAILURE);
                         }
                         return Err(e.into())
-                    } 
+                    }
                 }
             },
             (Some(_), Some(_)) => return Err(eyre!("`--plan` conflicts with passing a planner, a planner creates plans, so passing an existing plan doesn't make sense")),
@@ -134,7 +135,7 @@ impl CommandExecute for Install {
                     was_expected = true;
                     eprintln!("{}", expected.red())
                 }
-                if !was_expected { 
+                if !was_expected {
                     let error = eyre!(err).wrap_err("Install failure");
                     tracing::error!("{:?}", error);
                 };

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -129,8 +129,16 @@ impl CommandExecute for Install {
 
         if let Err(err) = install_plan.install(rx1).await {
             if !no_confirm {
-                let error = eyre!(err).wrap_err("Install failure");
-                tracing::error!("{:?}", error);
+                let mut was_expected = false;
+                if let Some(expected) = err.expected() {
+                    was_expected = true;
+                    eprintln!("{}", expected.red())
+                }
+                if !was_expected { 
+                    let error = eyre!(err).wrap_err("Install failure");
+                    tracing::error!("{:?}", error);
+                };
+
                 if !interaction::confirm(
                     install_plan
                         .describe_uninstall(explain)

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -34,11 +34,13 @@ impl CommandExecute for Plan {
 
         let install_plan = match res {
             Ok(plan) => plan,
-            Err(e) if e.expected() => {
-                eprintln!("{}", e.red());
-                return Ok(ExitCode::FAILURE);
+            Err(e) => {
+                if let Some(expected) = e.expected() {
+                    eprintln!("{}", expected.red());
+                    return Ok(ExitCode::FAILURE);
+                }
+                return Err(e.into());
             },
-            Err(e) => return Err(e.into()),
         };
 
         let json = serde_json::to_string_pretty(&install_plan)?;

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -1,9 +1,10 @@
 use std::{path::PathBuf, process::ExitCode};
 
-use crate::BuiltinPlanner;
+use crate::{error::HasExpectedErrors, BuiltinPlanner};
 use clap::Parser;
 
 use eyre::WrapErr;
+use owo_colors::OwoColorize;
 
 use crate::cli::CommandExecute;
 
@@ -29,7 +30,16 @@ impl CommandExecute for Plan {
                 .map_err(|e| eyre::eyre!(e))?,
         };
 
-        let install_plan = planner.plan().await.map_err(|e| eyre::eyre!(e))?;
+        let res = planner.plan().await;
+
+        let install_plan = match res {
+            Ok(plan) => plan,
+            Err(e) if e.expected() => {
+                eprintln!("{}", e.red());
+                return Ok(ExitCode::FAILURE);
+            },
+            Err(e) => return Err(e.into()),
+        };
 
         let json = serde_json::to_string_pretty(&install_plan)?;
         tokio::fs::write(output, json)

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -57,6 +57,9 @@ impl CommandExecute for Uninstall {
         // Instead, detect if we're in that location, if so, move the binary and `execv` it.
         if let Ok(current_exe) = std::env::current_exe() {
             if current_exe.as_path() == Path::new("/nix/harmonic") {
+                tracing::debug!(
+                    "Detected uninstall from `/nix/harmonic`, moving executable and re-executing"
+                );
                 let temp = std::env::temp_dir();
                 let temp_exe = temp.join("harmonic");
                 tokio::fs::copy(&current_exe, &temp_exe)

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, process::ExitCode};
+use std::{
+    ffi::CString,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
 
 use crate::{
     cli::{is_root, signal_channel},
@@ -45,6 +49,30 @@ impl CommandExecute for Uninstall {
             return Err(eyre!(
                 "`harmonic install` must be run as `root`, try `sudo harmonic install`"
             ));
+        }
+
+        // During install, `harmonic` will store a copy of itself in `/nix/harmonic`
+        // If the user opted to run that particular copy of Harmonic to do this uninstall,
+        // well, we have a problem, since the binary would delete itself.
+        // Instead, detect if we're in that location, if so, move the binary and `execv` it.
+        if let Ok(current_exe) = std::env::current_exe() {
+            if current_exe.as_path() == Path::new("/nix/harmonic") {
+                let temp = std::env::temp_dir();
+                let temp_exe = temp.join("harmonic");
+                tokio::fs::copy(&current_exe, &temp_exe)
+                    .await
+                    .wrap_err("Copying harmonic to tempdir")?;
+                let args = std::env::args();
+                let mut arg_vec_cstring = vec![];
+                for arg in args {
+                    arg_vec_cstring.push(CString::new(arg).wrap_err("Making arg into C string")?);
+                }
+                let temp_exe_cstring = CString::new(temp_exe.to_string_lossy().into_owned())
+                    .wrap_err("Making C string of executable path")?;
+
+                nix::unistd::execv(&temp_exe_cstring, &arg_vec_cstring)
+                    .wrap_err("Executing copied Harmonic")?;
+            }
         }
 
         let install_receipt_string = tokio::fs::read_to_string(receipt)

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -97,12 +97,11 @@ impl CommandExecute for Uninstall {
 
         let res = plan.uninstall(rx).await;
         if let Err(e) = res {
-            if e.expected() {
-                println!("{}", e.red());
+            if let Some(expected) = e.expected() {
+                println!("{}", expected.red());
                 return Ok(ExitCode::FAILURE);
-            } else {
-                return Err(e.into());
             }
+            return Err(e.into());
         }
 
         // TODO(@hoverbear): It would be so nice to catch errors and offer the user a way to keep going...

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,3 +54,22 @@ pub enum HarmonicError {
         InstallSettingsError,
     ),
 }
+
+pub(crate) trait HasExpectedErrors {
+    fn expected(&self) -> bool;
+}
+
+impl HasExpectedErrors for HarmonicError {
+    fn expected(&self) -> bool {
+        match self {
+            HarmonicError::Action(action_error) => action_error.expected(),
+            HarmonicError::RecordingReceipt(_, _) => false,
+            HarmonicError::CopyingSelf(_) => false,
+            HarmonicError::SerializingReceipt(_) => false,
+            HarmonicError::Cancelled => true,
+            HarmonicError::SemVer(_) => true,
+            HarmonicError::Planner(planner_error) => planner_error.expected(),
+            HarmonicError::InstallSettings(_) => false,
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,20 +56,20 @@ pub enum HarmonicError {
 }
 
 pub(crate) trait HasExpectedErrors {
-    fn expected(&self) -> bool;
+    fn expected<'a>(&'a self) -> Option<Box<dyn std::error::Error + 'a>>;
 }
 
 impl HasExpectedErrors for HarmonicError {
-    fn expected(&self) -> bool {
+    fn expected<'a>(&'a self) -> Option<Box<dyn std::error::Error + 'a>> {
         match self {
             HarmonicError::Action(action_error) => action_error.expected(),
-            HarmonicError::RecordingReceipt(_, _) => false,
-            HarmonicError::CopyingSelf(_) => false,
-            HarmonicError::SerializingReceipt(_) => false,
-            HarmonicError::Cancelled => true,
-            HarmonicError::SemVer(_) => true,
+            HarmonicError::RecordingReceipt(_, _) => None,
+            HarmonicError::CopyingSelf(_) => None,
+            HarmonicError::SerializingReceipt(_) => None,
+            HarmonicError::Cancelled => None,
+            HarmonicError::SemVer(_) => None,
             HarmonicError::Planner(planner_error) => planner_error.expected(),
-            HarmonicError::InstallSettings(_) => false,
+            HarmonicError::InstallSettings(_) => None,
         }
     }
 }

--- a/src/planner/linux/multi.rs
+++ b/src/planner/linux/multi.rs
@@ -33,7 +33,7 @@ impl Planner for LinuxMulti {
         // If on NixOS, running `harmonic` is pointless
         // NixOS always sets up this file as part of setting up /etc itself: https://github.com/NixOS/nixpkgs/blob/bdd39e5757d858bd6ea58ed65b4a2e52c8ed11ca/nixos/modules/system/etc/setup-etc.pl#L145
         if Path::new("/etc/NIXOS").exists() {
-            return Err(PlannerError::Custom(Box::new(LinuxMultiError::NixOs)));
+            return Err(PlannerError::NixOs);
         }
 
         // For now, we don't try to repair the user's Nix install or anything special.
@@ -43,7 +43,7 @@ impl Planner for LinuxMulti {
             .status()
             .await
         {
-            return Err(PlannerError::Custom(Box::new(LinuxMultiError::NixExists)));
+            return Err(PlannerError::NixExists);
         }
 
         Ok(vec![
@@ -84,10 +84,6 @@ impl Into<BuiltinPlanner> for LinuxMulti {
 
 #[derive(thiserror::Error, Debug)]
 enum LinuxMultiError {
-    #[error("NixOS already has Nix installed")]
-    NixOs,
-    #[error("`nix` is already a valid command, so it is installed")]
-    NixExists,
     #[error("Error planning action")]
     Action(
         #[source]

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -189,15 +189,15 @@ pub enum PlannerError {
 }
 
 impl HasExpectedErrors for PlannerError {
-    fn expected(&self) -> bool {
+    fn expected<'a>(&'a self) -> Option<Box<dyn std::error::Error + 'a>> {
         match self {
-            PlannerError::UnsupportedArchitecture(_) => true,
-            PlannerError::Action(_) => false,
-            PlannerError::InstallSettings(_) => false,
-            PlannerError::Plist(_) => false,
-            PlannerError::Custom(_) => false,
-            PlannerError::NixOs => true,
-            PlannerError::NixExists => true,
+            this @ PlannerError::UnsupportedArchitecture(_) => Some(Box::new(this)),
+            PlannerError::Action(_) => None,
+            PlannerError::InstallSettings(_) => None,
+            PlannerError::Plist(_) => None,
+            PlannerError::Custom(_) => None,
+            this @ PlannerError::NixOs => Some(Box::new(this)),
+            this @ PlannerError::NixExists => Some(Box::new(this)),
         }
     }
 }

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -81,6 +81,7 @@ use std::collections::HashMap;
 
 use crate::{
     action::{ActionError, StatefulAction},
+    error::HasExpectedErrors,
     settings::InstallSettingsError,
     Action, HarmonicError, InstallPlan,
 };
@@ -181,4 +182,22 @@ pub enum PlannerError {
     /// Custom planner error
     #[error("Custom planner error")]
     Custom(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("NixOS already has Nix installed")]
+    NixOs,
+    #[error("`nix` is already a valid command, so it is installed")]
+    NixExists,
+}
+
+impl HasExpectedErrors for PlannerError {
+    fn expected(&self) -> bool {
+        match self {
+            PlannerError::UnsupportedArchitecture(_) => true,
+            PlannerError::Action(_) => false,
+            PlannerError::InstallSettings(_) => false,
+            PlannerError::Plist(_) => false,
+            PlannerError::Custom(_) => false,
+            PlannerError::NixOs => true,
+            PlannerError::NixExists => true,
+        }
+    }
 }


### PR DESCRIPTION
Some errors, such as trying to install on NixOS, are expected, and do not require a full error output.

Eg:

```
❯ cargo run -- install
   Compiling harmonic v0.0.0-unreleased (/home/ana/git/determinatesystems/harmonic)
    Finished dev [unoptimized + debuginfo] target(s) in 10.15s
     Running `target/debug/harmonic install`
Harmonic needs to run as `root`, attempting to escalate now via `sudo`...
Error: 
   0: Planner error
   1: Custom planner error
   2: NixOS already has Nix installed

Location:
   /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/convert/mod.rs:552

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

Is just a bunch of information the user doesn't need in this particular case, because "NixOS already has Nix installed" is an expected error.

This creates a `HasExpectedErrors` trait that crate errors implement, the CLI (or callers) can then check to see if an error is something expected.

It's not sufficient to just return a `bool` since we need to return which error was expected, as it may be an arbitrary depth into the error chain.

The error now appears as

```
❯ cargo run -- install
   Compiling harmonic v0.0.0-unreleased (/home/ana/git/determinatesystems/harmonic)
    Finished dev [unoptimized + debuginfo] target(s) in 10.38s
     Running `target/debug/harmonic install`
Harmonic needs to run as `root`, attempting to escalate now via `sudo`...
NixOS already has Nix installed
```