### PR TITLE
Improve messaging on install failures and reverts

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,7 @@ impl HasExpectedErrors for HarmonicError {
             HarmonicError::RecordingReceipt(_, _) => None,
             HarmonicError::CopyingSelf(_) => None,
             HarmonicError::SerializingReceipt(_) => None,
-            HarmonicError::Cancelled => None,
+            this @ HarmonicError::Cancelled => Some(Box::new(this)),
             HarmonicError::SemVer(_) => None,
             HarmonicError::Planner(planner_error) => planner_error.expected(),
             HarmonicError::InstallSettings(_) => None,


### PR DESCRIPTION
I noticed if I cancelled an install I would still see "Success!" so I wiggled that around.

Eg:

![image](https://user-images.githubusercontent.com/130903/207162995-51ba53eb-f66a-4183-831e-237c076672fe.png)

Versus:

![image](https://user-images.githubusercontent.com/130903/207163081-b944d1d7-0ef5-4818-b85f-2b20792e15a3.png)

