### PR TITLE
Add action & Tune Tracing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
@@ -115,6 +116,7 @@ jobs:
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -168,6 +170,7 @@ jobs:
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           planner: steam-deck
           extra-args: --persistence ./ci-test-nix
       - name: Initial uninstall (without a `nix run` first)
@@ -179,6 +182,7 @@ jobs:
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           planner: steam-deck
           extra-args: --persistence ./ci-test-nix
       - name: echo $PATH
@@ -247,6 +251,7 @@ jobs:
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
@@ -256,6 +261,7 @@ jobs:
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
         run: sudo -E /nix/harmonic uninstall
         env:
           HARMONIC_NO_CONFIRM: true
+          HARMONIC_LOGGER: pretty
+          HARMONIC_LOG_DIRECTIVES: harmonic=trace
+          RUST_BACKTRACE: full
       - name: Repeated install
         uses: ./
         with:
@@ -144,6 +147,9 @@ jobs:
         run: sudo -E /nix/harmonic uninstall
         env:
           HARMONIC_NO_CONFIRM: true
+          HARMONIC_LOGGER: pretty
+          HARMONIC_LOG_DIRECTIVES: harmonic=trace
+          RUST_BACKTRACE: full
 
   run-steam-deck:
     name: Run Steam Deck (mock)
@@ -181,6 +187,9 @@ jobs:
         run: sudo -E /nix/harmonic uninstall
         env:
           HARMONIC_NO_CONFIRM: true
+          HARMONIC_LOGGER: pretty
+          HARMONIC_LOG_DIRECTIVES: harmonic=trace
+          RUST_BACKTRACE: full
       - name: Repeated install
         uses: ./
         with:
@@ -216,6 +225,9 @@ jobs:
         run: sudo -E /nix/harmonic uninstall
         env:
           HARMONIC_NO_CONFIRM: true
+          HARMONIC_LOGGER: pretty
+          HARMONIC_LOG_DIRECTIVES: harmonic=trace
+          RUST_BACKTRACE: full
 
   build-x86_64-darwin:
     name: Build x86_64 Darwin
@@ -264,6 +276,9 @@ jobs:
         run: sudo -E /nix/harmonic uninstall
         env:
           HARMONIC_NO_CONFIRM: true
+          HARMONIC_LOGGER: pretty
+          HARMONIC_LOG_DIRECTIVES: harmonic=trace
+          RUST_BACKTRACE: full
       - name: Repeated install
         uses: ./
         with:
@@ -297,4 +312,7 @@ jobs:
         run: sudo -E /nix/harmonic uninstall
         env:
           HARMONIC_NO_CONFIRM: true
+          HARMONIC_LOGGER: pretty
+          HARMONIC_LOG_DIRECTIVES: harmonic=trace
+          RUST_BACKTRACE: full
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,10 @@ jobs:
             echo "/nix exists"
             exit 1
           fi
+          if [ -e ./ci-test-nix ]; then
+            echo "./ci-test-nix exists"
+            exit 1
+          fi
       - name: Repeated install
         uses: ./
         with:
@@ -282,6 +286,10 @@ jobs:
           fi
           if [ -e /nix ]; then
             echo "/nix exists"
+            exit 1
+          fi
+          if [ -e ./ci-test-nix ]; then
+            echo "./ci-test-nix exists"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           planner: steam-deck
-          extra-args: --persistence ./ci-test-nix
+          extra-args: --persistence /home/runner/.ci-test-nix-home
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
         env:
@@ -232,8 +232,8 @@ jobs:
             echo "/nix exists"
             exit 1
           fi
-          if [ -e ./ci-test-nix ]; then
-            echo "./ci-test-nix exists"
+          if [ -e /home/runner/.ci-test-nix-home ]; then
+            echo "/home/runner/.ci-test-nix-home exists"
             exit 1
           fi
       - name: Repeated install
@@ -245,7 +245,7 @@ jobs:
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           planner: steam-deck
-          extra-args: --persistence ./ci-test-nix
+          extra-args: --persistence /home/runner/.ci-test-nix-home
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -288,8 +288,8 @@ jobs:
             echo "/nix exists"
             exit 1
           fi
-          if [ -e ./ci-test-nix ]; then
-            echo "./ci-test-nix exists"
+          if [ -e /home/runner/.ci-test-nix-home ]; then
+            echo "/home/runner/.ci-test-nix-home exists"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,6 @@ on:
   push:
     branches: [main]
 
-env:
-  NIX_INSTALL_FORCE_ALLOW_HTTP: "1"
-  NIX_INSTALL_UPDATE_ROOT: "http://0.0.0.0:8000"
-  RUST_BACKTRACE: "full"
-  HARMONIC_VERBOSITY: "2"
-  HARMONIC_NO_CONFIRM: "true"
-  HARMONIC_LOGGER: "pretty"
-
 jobs:
   lints:
     name: Lints
@@ -109,7 +101,7 @@ jobs:
       - name: Initial install
         uses: ./
         with:
-          harmonic-local-root: install-root/
+          local-root: install-root/
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
@@ -118,7 +110,7 @@ jobs:
       - name: Repeated install
         uses: ./
         with:
-          harmonic-local-root: install-root/
+          local-root: install-root/
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
@@ -169,7 +161,7 @@ jobs:
       - name: Initial install
         uses: ./
         with:
-          harmonic-local-root: install-root/
+          local-root: install-root/
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
@@ -180,7 +172,7 @@ jobs:
       - name: Repeated install
         uses: ./
         with:
-          harmonic-local-root: install-root/
+          local-root: install-root/
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
@@ -246,7 +238,7 @@ jobs:
       - name: Initial install
         uses: ./
         with:
-          harmonic-local-root: install-root/
+          local-root: install-root/
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full
@@ -255,7 +247,7 @@ jobs:
       - name: Repeated install
         uses: ./
         with:
-          harmonic-local-root: install-root/
+          local-root: install-root/
           logger: pretty
           log-directives: harmonic=trace
           backtrace: full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
+        env:
+          HARMONIC_NO_CONFIRM: true
       - name: Repeated install
         uses: ./
         with:
@@ -140,6 +142,8 @@ jobs:
         shell: fish --login {0}
       - name: Repeated uninstall
         run: sudo -E /nix/harmonic uninstall
+        env:
+          HARMONIC_NO_CONFIRM: true
 
   run-steam-deck:
     name: Run Steam Deck (mock)
@@ -175,6 +179,8 @@ jobs:
           extra-args: --persistence ./ci-test-nix
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
+        env:
+          HARMONIC_NO_CONFIRM: true
       - name: Repeated install
         uses: ./
         with:
@@ -208,6 +214,8 @@ jobs:
         shell: fish --login {0}
       - name: Repeated uninstall
         run: sudo -E /nix/harmonic uninstall
+        env:
+          HARMONIC_NO_CONFIRM: true
 
   build-x86_64-darwin:
     name: Build x86_64 Darwin
@@ -254,6 +262,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
+        env:
+          HARMONIC_NO_CONFIRM: true
       - name: Repeated install
         uses: ./
         with:
@@ -285,4 +295,6 @@ jobs:
         shell: fish --login {0}
       - name: Repeated uninstall
         run: sudo -E /nix/harmonic uninstall
+        env:
+          HARMONIC_NO_CONFIRM: true
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,18 @@ jobs:
         uses: ./
         with:
           harmonic-local-root: install-root/
+          logger: pretty
+          log-directives: harmonic=trace
+          backtrace: full
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
         uses: ./
         with:
           harmonic-local-root: install-root/
+          logger: pretty
+          log-directives: harmonic=trace
+          backtrace: full
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -164,6 +170,9 @@ jobs:
         uses: ./
         with:
           harmonic-local-root: install-root/
+          logger: pretty
+          log-directives: harmonic=trace
+          backtrace: full
           planner: steam-deck
           extra-args: --persistence ./ci-test-nix
       - name: Initial uninstall (without a `nix run` first)
@@ -172,6 +181,9 @@ jobs:
         uses: ./
         with:
           harmonic-local-root: install-root/
+          logger: pretty
+          log-directives: harmonic=trace
+          backtrace: full
           planner: steam-deck
           extra-args: --persistence ./ci-test-nix
       - name: echo $PATH
@@ -235,12 +247,18 @@ jobs:
         uses: ./
         with:
           harmonic-local-root: install-root/
+          logger: pretty
+          log-directives: harmonic=trace
+          backtrace: full
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
         uses: ./
         with:
           harmonic-local-root: install-root/
+          logger: pretty
+          log-directives: harmonic=trace
+          backtrace: full
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,20 @@ jobs:
           HARMONIC_LOGGER: pretty
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run:
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
       - name: Repeated install
         uses: ./
         with:
@@ -150,6 +164,20 @@ jobs:
           HARMONIC_LOGGER: pretty
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run:
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
 
   run-steam-deck:
     name: Run Steam Deck (mock)
@@ -190,6 +218,20 @@ jobs:
           HARMONIC_LOGGER: pretty
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run:
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
       - name: Repeated install
         uses: ./
         with:
@@ -228,6 +270,20 @@ jobs:
           HARMONIC_LOGGER: pretty
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run:
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
 
   build-x86_64-darwin:
     name: Build x86_64 Darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,6 @@ jobs:
         run: nix develop --store ~/.ci-store --command check-nixpkgs-fmt
       - name: Check EditorConfig conformance
         run: nix develop --store ~/.ci-store --command check-editorconfig
-      - name: Create artifact for `nix-install.sh`
-        uses: actions/upload-artifact@v3
-        with:
-          name: nix-install
-          path: |
-            nix-install.sh
 
   build-x86_64-linux:
     name: Build x86_64 Linux
@@ -107,22 +101,19 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: harmonic-x86_64-linux
-      - uses: actions/download-artifact@v3
-        with:
-          name: nix-install
       - name: Move & set executable
         run: |
           chmod +x ./harmonic
           mkdir install-root
           mv harmonic install-root/harmonic-x86_64-linux
       - name: Initial install
-        uses: ./action.yml
+        uses: ./
         with:
           harmonic-local-root: install-root/
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
-        uses: ./action.yml
+        uses: ./
         with:
           harmonic-local-root: install-root/
       - name: echo $PATH
@@ -159,9 +150,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: harmonic-x86_64-linux
-      - uses: actions/download-artifact@v3
-        with:
-          name: nix-install
       - name: Move & set executable
         run: |
           chmod +x ./harmonic
@@ -173,7 +161,7 @@ jobs:
           sudo chmod +x /bin/steamos-readonly
           sudo useradd -m deck
       - name: Initial install
-        uses: ./action.yml
+        uses: ./
         with:
           harmonic-local-root: install-root/
           planner: steam-deck
@@ -181,7 +169,7 @@ jobs:
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
-        uses: ./action.yml
+        uses: ./
         with:
           harmonic-local-root: install-root/
           planner: steam-deck
@@ -239,21 +227,18 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: harmonic-x86_64-darwin
-      - uses: actions/download-artifact@v3
-        with:
-          name: nix-install
       - name: Move & set executable
         run: |
           chmod +x ./harmonic
           mv harmonic harmonic-x86_64-darwin
       - name: Initial install
-        uses: ./action.yml
+        uses: ./
         with:
           harmonic-local-root: install-root/
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
-        uses: ./action.yml
+        uses: ./
         with:
           harmonic-local-root: install-root/
       - name: echo $PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build-x86_64-linux, lints]
     steps:
+      - uses: actions/checkout@v3
       - run: sudo apt install fish zsh
       - uses: actions/download-artifact@v3
         with:
@@ -153,6 +154,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build-x86_64-linux, lints]
     steps:
+      - uses: actions/checkout@v3
       - run: sudo apt install fish zsh
       - uses: actions/download-artifact@v3
         with:
@@ -232,6 +234,7 @@ jobs:
     runs-on: macos-12
     needs: [build-x86_64-darwin, lints]
     steps:
+      - uses: actions/checkout@v3
       - run: brew install fish coreutils
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
-        run:
+        run: |
           if systemctl is-active nix-daemon.socket; then
             echo "nix-daemon.socket was still running"
             exit 1
@@ -165,7 +165,7 @@ jobs:
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
-        run:
+        run: |
           if systemctl is-active nix-daemon.socket; then
             echo "nix-daemon.socket was still running"
             exit 1
@@ -219,7 +219,7 @@ jobs:
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
-        run:
+        run: |
           if systemctl is-active nix-daemon.socket; then
             echo "nix-daemon.socket was still running"
             exit 1
@@ -271,7 +271,7 @@ jobs:
           HARMONIC_LOG_DIRECTIVES: harmonic=trace
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
-        run:
+        run: |
           if systemctl is-active nix-daemon.socket; then
             echo "nix-daemon.socket was still running"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           chmod +x ./harmonic
           mkdir install-root
+          cp nix-install.sh install-root/nix-install.sh
           mv harmonic install-root/harmonic-x86_64-linux
       - name: Initial install
         uses: ./
@@ -151,7 +152,9 @@ jobs:
       - name: Move & set executable
         run: |
           chmod +x ./harmonic
-          mv harmonic harmonic-x86_64-linux
+          mkdir install-root
+          cp nix-install.sh install-root/nix-install.sh
+          mv harmonic install-root/harmonic-x86_64-linux
       - name: Make the CI look like a steam deck
         run: |
           mkdir -p ~/bin
@@ -234,7 +237,9 @@ jobs:
       - name: Move & set executable
         run: |
           chmod +x ./harmonic
-          mv harmonic harmonic-x86_64-darwin
+          mkdir install-root
+          cp nix-install.sh install-root/nix-install.sh
+          mv harmonic install-root/harmonic-x86_64-darwin
       - name: Initial install
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,19 +112,18 @@ jobs:
       - name: Move & set executable
         run: |
           chmod +x ./harmonic
-          mv harmonic harmonic-x86_64-linux
+          mkdir install-root
+          mv harmonic install-root/harmonic-x86_64-linux
       - name: Initial install
-        run: |
-          python -m http.server --bind 0.0.0.0 8000 &
-          timeout 20 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/localhost/8000; do echo "Waiting for server..."; sleep 1; done'
-          curl -L http://0.0.0.0:8000/nix-install.sh | sh -s -- install linux-multi --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        uses: ./action.yml
+        with:
+          harmonic-local-root: install-root/
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
-        run: |
-          python -m http.server --bind 0.0.0.0 8000 &
-          timeout 20 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/localhost/8000; do echo "Waiting for server..."; sleep 1; done'
-          curl -L http://0.0.0.0:8000/nix-install.sh | sh -s -- install linux-multi --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        uses: ./action.yml
+        with:
+          harmonic-local-root: install-root/
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -172,17 +171,19 @@ jobs:
           sudo chmod +x /bin/steamos-readonly
           sudo useradd -m deck
       - name: Initial install
-        run: |
-          python -m http.server --bind 0.0.0.0 8000 &
-          timeout 20 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/localhost/8000; do echo "Waiting for server..."; sleep 1; done'
-          curl -L http://0.0.0.0:8000/nix-install.sh | sh -s -- install steam-deck --persistence `pwd`/ci-test-nix --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        uses: ./action.yml
+        with:
+          harmonic-local-root: install-root/
+          planner: steam-deck
+          extra-args: --persistence ./ci-test-nix
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
-        run: |
-          python -m http.server --bind 0.0.0.0 8000 &
-          timeout 20 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/localhost/8000; do echo "Waiting for server..."; sleep 1; done'
-          curl -L http://0.0.0.0:8000/nix-install.sh | sh -s -- install steam-deck --persistence `pwd`/ci-test-nix --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        uses: ./action.yml
+        with:
+          harmonic-local-root: install-root/
+          planner: steam-deck
+          extra-args: --persistence ./ci-test-nix
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -243,17 +244,15 @@ jobs:
           chmod +x ./harmonic
           mv harmonic harmonic-x86_64-darwin
       - name: Initial install
-        run: |
-          python3 -m http.server --bind 0.0.0.0 8000 &
-          gtimeout 20 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/localhost/8000; do echo "Waiting for server..."; sleep 1; done'
-          curl -L http://0.0.0.0:8000/nix-install.sh | sh -s -- install darwin-multi --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        uses: ./action.yml
+        with:
+          harmonic-local-root: install-root/
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/harmonic uninstall
       - name: Repeated install
-        run: |
-          python -m http.server --bind 0.0.0.0 8000 &
-          timeout 20 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/localhost/8000; do echo "Waiting for server..."; sleep 1; done'
-          curl -L http://0.0.0.0:8000/nix-install.sh | sh -s -- install darwin-multi --extra-conf "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        uses: ./action.yml
+        with:
+          harmonic-local-root: install-root/
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ dependencies = [
  "tracing-subscriber",
  "typetag",
  "url",
- "valuable",
  "walkdir",
  "xz2",
 ]
@@ -2114,8 +2113,6 @@ checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -2137,8 +2134,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -2227,30 +2222,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-dependencies = [
- "valuable-derive",
-]
-
-[[package]]
-name = "valuable-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44690c645190cfce32f91a1582281654b2338c6073fa250b0949fd25c55b32"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "valuable-serde"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285cfff30cdabe26626736a54d989687dd9cab84f51f4048b61d6d0ae8b0907"
-dependencies = [
- "serde",
- "valuable",
-]
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,10 @@ target-lexicon = "0.12.4"
 thiserror = "1.0.33"
 tokio = { version = "1.21.0", features = ["time", "io-std", "process", "fs", "signal", "tracing", "rt-multi-thread", "macros", "io-util", "parking_lot" ] }
 tokio-util = { version = "0.7", features = ["io"] }
-tracing = { version = "0.1.36", features = [ "valuable" ] }
+tracing = { version = "0.1.36" }
 tracing-error = { version = "0.2.0", optional = true }
-tracing-subscriber = { version = "0.3.15", features = [ "json", "env-filter", "valuable" ], optional = true }
+tracing-subscriber = { version = "0.3.15", features = [ "json", "env-filter" ], optional = true }
 url = { version = "2.3.1", features = ["serde"] }
-valuable = { version = "0.1.0", features = ["derive"] }
 walkdir = "2.3.2"
 sxd-xpath = "0.4.2"
 xz2 = { version = "0.1.7", features = ["static", "tokio"] }

--- a/README.md
+++ b/README.md
@@ -174,3 +174,27 @@ Documentation is also available via `nix` build:
 nix build github:DeterminateSystems/harmonic#harmonic.doc
 firefox result-doc/harmonic/index.html
 ```
+
+## As a Github Action
+
+You can use Harmonic as a Github action like so:
+
+```yaml
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lints:
+    name: Build
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Nix
+      uses: determinatesystems/harmonic@main
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build
+      run: nix build .#
+```

--- a/README.md
+++ b/README.md
@@ -195,6 +195,6 @@ jobs:
       uses: determinatesystems/harmonic@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
-      run: nix build .#
+    - name: Run `nix build`
+      run: nix build .
 ```

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Nix
-      uses: determinatesystems/harmonic@main
+      uses: DeterminateSystems/harmonic@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run `nix build`

--- a/action.yml
+++ b/action.yml
@@ -74,34 +74,42 @@ runs:
       run: |
         if [ -n "${INPUT_CHANNELS-}" ]; then
           export HARMONIC_CHANNELS=$INPUT_CHANNELS
+          echo "Setting HARMONIC_CHANNELS=$HARMONIC_CHANNELS"
         fi
 
         if [ -n "${INPUT_MODIFY-PROFILE-}" ]; then
           export HARMONIC_MODIFY_PROFILE=$INPUT_MODIFY-PROFILE
+          echo "Setting HARMONIC_MODIFY_PROFILE=$HARMONIC_MODIFY_PROFILE"
         fi
 
         if [ -n "${INPUT_DAEMON-USER-COUNT-}" ]; then
           export HARMONIC_DAEMON_USER_COUNT=$INPUT_DAEMON-USER-COUNT
+          echo "Setting HARMONIC_DAEMON_USER_COUNT=$HARMONIC_DAEMON_USER_COUNT"
         fi
 
         if [ -n "${INPUT_NIX-BUILD-GROUP-NAME-}" ]; then
           export HARMONIC_NIX_BUILD_GROUP_NAME=$INPUT_NIX-BUILD-GROUP-NAME
+          echo "Setting HARMONIC_NIX_BUILD_GROUP_NAME=$HARMONIC_NIX_BUILD_GROUP_NAME"
         fi
 
         if [ -n "${INPUT_NIX-BUILD-BUILD-GROUP-ID-}" ]; then
           export HARMONIC_NIX_BUILD_GROUP_ID=$INPUT_NIX-BUILD-BUILD-GROUP-ID
+          echo "Setting HARMONIC_NIX_BUILD_GROUP_ID=$HARMONIC_NIX_BUILD_GROUP_ID"
         fi
 
         if [ -n "${INPUT_NIX-BUILD-BUILD-GROUP-ID-}" ]; then
           export HARMONIC_NIX_BUILD_USER_PREFIX=$INPUT_NIX-BUILD-BUILD-GROUP-ID
+          echo "Setting HARMONIC_NIX_BUILD_USER_PREFIX=$HARMONIC_NIX_BUILD_USER_PREFIX"
         fi
 
         if [ -n "${INPUT_NIX-BUILD-USER-BASE-}" ]; then
           export HARMONIC_NIX_BUILD_USER_ID_BASE=$INPUT_NIX-BUILD-USER-BASE
+          echo "Setting HARMONIC_NIX_BUILD_USER_ID_BASE=$HARMONIC_NIX_BUILD_USER_ID_BASE"
         fi
 
         if [ -n "${INPUT_NIX-PACKAGE-URL-}" ]; then
           export HARMONIC_NIX_PACKAGE_URL=$INPUT_NIX-PACKAGE-URL
+          echo "Setting HARMONIC_NIX_PACKAGE_URL=$HARMONIC_NIX_PACKAGE_URL"
         fi
 
         if [ -n "${INPUT_EXTRA-CONF-}" ]; then
@@ -109,50 +117,61 @@ runs:
             export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF\naccess-tokens = github.com=$INPUT_GITHUB-TOKEN"
           fi
           export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF"
+          echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
         else
           if [ -n "${INPUT_GITHUB-TOKEN-}" ]; then
             export HARMONIC_EXTRA_CONF="access-tokens = github.com=$INPUT_GITHUB-TOKEN"
+            echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
           fi
         fi
 
         if [ -n "${INPUT_MAC-ENCRYPT-}" ]; then
           export HARMONIC_ENCRYPT=$INPUT_MAC-ENCRYPT
+          echo "Setting HARMONIC_ENCRYPT=$HARMONIC_ENCRYPT"
         fi
 
         if [ -n "${INPUT_MAC-CASE-SENSITIVE-}" ]; then
           export HARMONIC_CASE_SENSITIVE=$INPUT_MAC-CASE-SENSITIVE
+          echo "Setting HARMONIC_CASE_SENSITIVE=$HARMONIC_CASE_SENSITIVE"
         fi
 
         if [ -n "${INPUT_MAC-VOLUME-LABEL-}" ]; then
           export HARMONIC_VOLUME_LABEL=$INPUT_MAC-VOLUME-LABEL
+          echo "Setting HARMONIC_VOLUME_LABEL=$HARMONIC_VOLUME_LABEL"
         fi
 
         if [ -n "${INPUT_MAC-ROOT-DISK-}" ]; then
           export HARMONIC_ROOT_DISK=$INPUT_MAC-ROOT-DISK
+          echo "Setting HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
         fi
 
         if [ -n "${INPUT_MAC-ROOT-DISK-}" ]; then
           export HARMONIC_ROOT_DISK=$INPUT_MAC-ROOT-DISK
+          echo "Setting HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
         fi
 
         if [ -n "${INPUT_HARMONIC-LOCAL-ROOT-}" ]; then
           python -m http.server --directory install-root/ --bind 0.0.0.0 8000 &
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
-            sleep 1;
+            sleep 1
           done
           export NIX_INSTALL_URL=0.0.0.0:8000
+          echo "Setting NIX_INSTALL_URL=$NIX_INSTALL_URL"
         fi
 
         if [ -n "${INPUT_LOGGER-}" ]; then
           export HARMONIC_LOGGER=$INPUT_LOGGER
+          echo "Setting HARMONIC_LOGGER=$HARMONIC_LOGGER"
         fi
 
         if [ -n "${INPUT_LOG-DIRECTIVES-}" ]; then
           export HARMONIC_LOG_DIRECTIVES=$INPUT_LOG-DIRECTIVES
+          echo "Setting HARMONIC_LOG_DIRECTIVES=$HARMONIC_LOG_DIRECTIVES"
         fi
 
         if [ -n "${INPUT_BACKTRACE-}" ]; then
           export RUST_BACKTRACE=$INPUT_BACKTRACE
+          echo "Setting RUST_BACKTRACE=$RUST_BACKTRACE"
         fi
 
         curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}

--- a/action.yml
+++ b/action.yml
@@ -154,8 +154,8 @@ runs:
           done
           export NIX_INSTALL_URL=0.0.0.0:8000/nix-install.sh
           echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL/nix-install.sh"
-          export NIX_INSTALL_UPDATE_ROOT=http://0.0.0.0:8000/
-          echo "Set NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_UPDATE_ROOT"
+          export NIX_INSTALL_BINARY_ROOT=http://0.0.0.0:8000/
+          echo "Set NIX_INSTALL_BINARY_ROOT=$NIX_INSTALL_BINARY_ROOT"
           export NIX_INSTALL_FORCE_ALLOW_HTTP=1
           echo "Set NIX_INSTALL_FORCE_ALLOW_HTTP=$NIX_INSTALL_FORCE_ALLOW_HTTP"
         else

--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
         fi
 
         if [ -n "${{ inputs.nix-package-url }}" ]; then
-          if [ -n "${{ inputsgithub-token }}" ]; then
+          if [ -n "${{ inputs.github-token }}" ]; then
             export HARMONIC_EXTRA_CONF="${{ inputs.nix-package-url }}\naccess-tokens = github.com=${{ inputs.github-token }}"
           else
             export HARMONIC_EXTRA_CONF="${{ inputs.nix-package-url }}"

--- a/action.yml
+++ b/action.yml
@@ -112,15 +112,15 @@ runs:
           echo "Set HARMONIC_NIX_PACKAGE_URL=$HARMONIC_NIX_PACKAGE_URL"
         fi
 
-        if [ -n "${{ inputs.nix-package-url }}" ]; then
+        if [ -n "${{ inputs.extra-conf }}" ]; then
           if [ -n "${{ inputs.github-token }}" ]; then
-            export HARMONIC_EXTRA_CONF="${{ inputs.nix-package-url }}\naccess-tokens = github.com=${{ inputs.github-token }}"
+            export HARMONIC_EXTRA_CONF="${{ inputs.extra-conf }}\naccess-tokens = github.com=${{ inputs.github-token }}"
           else
-            export HARMONIC_EXTRA_CONF="${{ inputs.nix-package-url }}"
+            export HARMONIC_EXTRA_CONF="${{ inputs.extra-conf }}"
           fi
           echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
         else
-          if [ -n "${{ inputs.nix-package-url }}" ]; then
+          if [ -n "${{ inputs.github-token }}" ]; then
             export HARMONIC_EXTRA_CONF="access-tokens = github.com=${{ inputs.github-token }}"
             echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
           fi

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ inputs:
   extra-args:
     description: Extra args to pass to the planner (prefer using structured `with:` arguments unless using a custom planner!)
     required: false
+  github-token:
+    description: A Github Token so that authenticated requests can be made (set this to `${{ secrets.GITHUB_TOKEN }}`)
   channels:
     description: Channel(s) to add (eg `nixpkgs=https://nixos.org/channels/nixpkgs-unstable`)
     required: false
@@ -32,7 +34,7 @@ inputs:
     description: The Nix package URL
     required: false
   extra-conf:
-    description: Extra configuration lines for `/etc/nix.conf` (includes `access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}` automatically)
+    description: Extra configuration lines for `/etc/nix.conf` (includes `access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}` automatically if `github-token` is set)
     required: false
   mac-encrypt:
     description: Force encryption on the volume (Mac only)
@@ -92,9 +94,14 @@ runs:
         fi
 
         if [ -n "${INPUT_EXTRA-CONF-}" ]; then
-          export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF\naccess-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+          if [ -n "${INPUT_GITHUB-TOKEN-}" ]; then
+            export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF\naccess-tokens = github.com=$INPUT_GITHUB-TOKEN"
+          fi
+          export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF"
         else
-          export HARMONIC_EXTRA_CONF="access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+          if [ -n "${INPUT_GITHUB-TOKEN-}" ]; then
+            export HARMONIC_EXTRA_CONF="access-tokens = github.com=$INPUT_GITHUB-TOKEN"
+          fi
         fi
 
         if [ -n "${INPUT_MAC-ENCRYPT-}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,7 @@ runs:
 
         if [ -n "${{ inputs.local-root }}" ]; then
           python -m http.server --directory ${{ inputs.local-root }} --bind 0.0.0.0 8000 &
+          export HTTP_PID=$!
           echo "Started simple http server for ${{ inputs.local-root }} on 0.0.0.0:8000"
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
             sleep 1
@@ -183,5 +184,10 @@ runs:
         echo "Set HARMONIC_NO_CONFIRM=$HARMONIC_NO_CONFIRM"
 
         curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}
+
+        if [ -n "$HTTP_PID" ]; then
+          kill $HTTP_PID
+        fi
+
 
 

--- a/action.yml
+++ b/action.yml
@@ -148,11 +148,14 @@ runs:
 
         if [ -n "${{ inputs.local-root }}" ]; then
           python -m http.server --directory ${{ inputs.local-root }} --bind 0.0.0.0 8000 &
+          echo "Started simple http server for ${{ inputs.local-root }} on 0.0.0.0:8000"
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
             sleep 1
           done
           export NIX_INSTALL_URL=0.0.0.0:8000
           echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"
+          export NIX_INSTALL_FORCE_ALLOW_HTTP=1
+          echo "Set NIX_INSTALL_FORCE_ALLOW_HTTP=$NIX_INSTALL_FORCE_ALLOW_HTTP"
         else
           export NIX_INSTALL_URL=${{ inputs.nix-install-url }}
           echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,8 @@ runs:
           done
           export NIX_INSTALL_URL=0.0.0.0:8000
           echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"
+          export NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_URL
+          echo "Set NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_UPDATE_ROOT"
           export NIX_INSTALL_FORCE_ALLOW_HTTP=1
           echo "Set NIX_INSTALL_FORCE_ALLOW_HTTP=$NIX_INSTALL_FORCE_ALLOW_HTTP"
         else

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ inputs:
     description: A URL pointing to a harmonic `nix-install.sh` script
     required: true
     default: https://install.determinate.systems/nix
-  harmonic-local-root:
+  local-root:
     description: A local `harmonic` binary root, overrides the `nix-install` setting (binaries should be named `harmonic-$ARCH`, eg. `harmonic-$x86_64-linux`)
     required: false
   logger:
@@ -72,111 +72,107 @@ runs:
     - name: Install Nix
       shell: bash
       run: |
-        if [ -n "${INPUT_CHANNELS-}" ]; then
-          export HARMONIC_CHANNELS=$INPUT_CHANNELS
-          echo "Setting HARMONIC_CHANNELS=$HARMONIC_CHANNELS"
+        if [ -n "${{ inputs.channels }}" ]; then
+          export HARMONIC_CHANNELS=${{ inputs.channels }}
+          echo "Set HARMONIC_CHANNELS=$HARMONIC_CHANNELS"
         fi
 
-        if [ -n "${INPUT_MODIFY_PROFILE-}" ]; then
-          export HARMONIC_MODIFY_PROFILE=$INPUT_MODIFY_PROFILE
-          echo "Setting HARMONIC_MODIFY_PROFILE=$HARMONIC_MODIFY_PROFILE"
+        if [ -n "${{ inputs.modify-profile }}" ]; then
+          export HARMONIC_MODIFY_PROFILE=${{ inputs.modify-profile }}
+          echo "Set HARMONIC_MODIFY_PROFILE=$HARMONIC_MODIFY_PROFILE"
         fi
 
-        if [ -n "${INPUT_DAEMON_USER_COUNT-}" ]; then
-          export HARMONIC_DAEMON_USER_COUNT=$INPUT_DAEMON_USER_COUNT
-          echo "Setting HARMONIC_DAEMON_USER_COUNT=$HARMONIC_DAEMON_USER_COUNT"
+        if [ -n "${{ inputs.daemon-user-count }}" ]; then
+          export HARMONIC_DAEMON_USER_COUNT=${{ inputs.daemon-user-count }}
+          echo "Set HARMONIC_DAEMON_USER_COUNT=$HARMONIC_DAEMON_USER_COUNT"
         fi
 
-        if [ -n "${INPUT_NIX_BUILD_GROUP_NAME-}" ]; then
-          export HARMONIC_NIX_BUILD_GROUP_NAME=$INPUT_NIX_BUILD_GROUP_NAME
-          echo "Setting HARMONIC_NIX_BUILD_GROUP_NAME=$HARMONIC_NIX_BUILD_GROUP_NAME"
+        if [ -n "${{ inputs.nix-build-group-name }}" ]; then
+          export HARMONIC_NIX_BUILD_GROUP_NAME=${{ inputs.nix-build-group-name }}
+          echo "Set HARMONIC_NIX_BUILD_GROUP_NAME=$HARMONIC_NIX_BUILD_GROUP_NAME"
         fi
 
-        if [ -n "${INPUT_NIX_BUILD_GROUP_ID-}" ]; then
-          export HARMONIC_NIX_BUILD_GROUP_ID=$INPUT_NIX_BUILD_GROUP_ID
-          echo "Setting HARMONIC_NIX_BUILD_GROUP_ID=$HARMONIC_NIX_BUILD_GROUP_ID"
+        if [ -n "${{ inputs.nix-build-group-id }}" ]; then
+          export HARMONIC_NIX_BUILD_GROUP_ID=${{ inputs.nix-build-group-id }}
+          echo "Set HARMONIC_NIX_BUILD_GROUP_ID=$HARMONIC_NIX_BUILD_GROUP_ID"
         fi
 
-        if [ -n "${INPUT_NIX_BUILD_GROUP_ID-}" ]; then
-          export HARMONIC_NIX_BUILD_USER_PREFIX=$INPUT_NIX_BUILD_GROUP_ID
-          echo "Setting HARMONIC_NIX_BUILD_USER_PREFIX=$HARMONIC_NIX_BUILD_USER_PREFIX"
+        if [ -n "${{ inputs.nix-build-user-prefix }}" ]; then
+          export HARMONIC_NIX_BUILD_USER_ID_BASE=${{ inputs.nix-build-user-prefix }}
+          echo "Set HARMONIC_NIX_BUILD_USER_ID_BASE=$HARMONIC_NIX_BUILD_USER_ID_BASE"
         fi
 
-        if [ -n "${INPUT_NIX_BUILD_USER_BASE-}" ]; then
-          export HARMONIC_NIX_BUILD_USER_ID_BASE=$INPUT_NIX_BUILD_USER_BASE
-          echo "Setting HARMONIC_NIX_BUILD_USER_ID_BASE=$HARMONIC_NIX_BUILD_USER_ID_BASE"
+        if [ -n "${{ inputs.nix-build-user-base }}" ]; then
+          export HARMONIC_NIX_BUILD_USER_PREFIX=${{ inputs.nix-build-user-base }}
+          echo "Set HARMONIC_NIX_BUILD_USER_PREFIX=$HARMONIC_NIX_BUILD_USER_PREFIX"
         fi
 
-        if [ -n "${INPUT_NIX_PACKAGE_URL-}" ]; then
-          export HARMONIC_NIX_PACKAGE_URL=$INPUT_NIX_PACKAGE_URL
-          echo "Setting HARMONIC_NIX_PACKAGE_URL=$HARMONIC_NIX_PACKAGE_URL"
+        if [ -n "${{ inputs.nix-package-url }}" ]; then
+          export HARMONIC_NIX_PACKAGE_URL=${{ inputs.nix-package-url }}
+          echo "Set HARMONIC_NIX_PACKAGE_URL=$HARMONIC_NIX_PACKAGE_URL"
         fi
 
-        if [ -n "${INPUT_EXTRA_CONF-}" ]; then
-          if [ -n "${INPUT_GITHUB_TOKEN-}" ]; then
-            export HARMONIC_EXTRA_CONF="$INPUT_EXTRA_CONF\naccess-tokens = github.com=$INPUT_GITHUB_TOKEN"
+        if [ -n "${{ inputs.nix-package-url }}" ]; then
+          if [ -n "${{ inputsgithub-token }}" ]; then
+            export HARMONIC_EXTRA_CONF="${{ inputs.nix-package-url }}\naccess-tokens = github.com=${{ inputs.github-token }}"
+          else
+            export HARMONIC_EXTRA_CONF="${{ inputs.nix-package-url }}"
           fi
-          export HARMONIC_EXTRA_CONF="$INPUT_EXTRA_CONF"
           echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
         else
-          if [ -n "${INPUT_GITHUB-TOKEN-}" ]; then
-            export HARMONIC_EXTRA_CONF="access_tokens = github.com=$INPUT_GITHUB_TOKEN"
+          if [ -n "${{ inputs.nix-package-url }}" ]; then
+            export HARMONIC_EXTRA_CONF="access-tokens = github.com=${{ inputs.github-token }}"
             echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
           fi
         fi
 
-        if [ -n "${INPUT_MAC_ENCRYPT-}" ]; then
-          export HARMONIC_ENCRYPT=$INPUT_MAC_ENCRYPT
-          echo "Setting HARMONIC_ENCRYPT=$HARMONIC_ENCRYPT"
+        if [ -n "${{ inputs.mac-encrypt }}" ]; then
+          export HARMONIC_ENCRYPT=${{ inputs.mac-encrypt }}
+          echo "Set HARMONIC_ENCRYPT=$HARMONIC_ENCRYPT"
         fi
 
-        if [ -n "${INPUT_MAC_CASE_SENSITIVE-}" ]; then
-          export HARMONIC_CASE_SENSITIVE=$INPUT_MAC_CASE_SENSITIVE
-          echo "Setting HARMONIC_CASE_SENSITIVE=$HARMONIC_CASE_SENSITIVE"
+        if [ -n "${{ inputs.mac-case-sensitive }}" ]; then
+          export HARMONIC_CASE_SENSITIVE=${{ inputs.mac-case-sensitive }}
+          echo "Set HARMONIC_CASE_SENSITIVE=$HARMONIC_CASE_SENSITIVE"
         fi
 
-        if [ -n "${INPUT_MAC_VOLUME_LABEL-}" ]; then
-          export HARMONIC_VOLUME_LABEL=$INPUT_MAC_VOLUME_LABEL
-          echo "Setting HARMONIC_VOLUME_LABEL=$HARMONIC_VOLUME_LABEL"
+        if [ -n "${{ inputs.mac-volume-label }}" ]; then
+          export HARMONIC_VOLUME_LABEL=${{ inputs.mac-volume-label }}
+          echo "Set HARMONIC_VOLUME_LABEL=$HARMONIC_VOLUME_LABEL"
         fi
 
-        if [ -n "${INPUT_MAC_ROOT_DISK-}" ]; then
-          export HARMONIC_ROOT_DISK=$INPUT_MAC_ROOT_DISK
-          echo "Setting HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
+        if [ -n "${{ inputs.mac-root-disk }}" ]; then
+          export HARMONIC_ROOT_DISK=${{ inputs.mac-root-disk }}
+          echo "Set HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
         fi
 
-        if [ -n "${INPUT_MAC_ROOT_DISK-}" ]; then
-          export HARMONIC_ROOT_DISK=$INPUT_MAC_ROOT_DISK
-          echo "Setting HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
-        fi
-
-        if [ -n "${INPUT_HARMONIC_LOCAL_ROOT-}" ]; then
-          python -m http.server --directory install-root/ --bind 0.0.0.0 8000 &
+        if [ -n "${{ inputs.local-root }}" ]; then
+          python -m http.server --directory ${{ inputs.local-root }} --bind 0.0.0.0 8000 &
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
             sleep 1
           done
           export NIX_INSTALL_URL=0.0.0.0:8000
-          echo "Setting NIX_INSTALL_URL=$INPUT_NIX_INSTALL_URL"
+          echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"
         else
-          export NIX_INSTALL_URL=$INPUT_NIX_INSTALL_URL
-          echo "Setting NIX_INSTALL_URL=$NIX_INSTALL_URL"
+          export NIX_INSTALL_URL=${{ inputs.nix-install-url }}
+          echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"
         fi
 
-        if [ -n "${INPUT_LOGGER-}" ]; then
-          export HARMONIC_LOGGER=$INPUT_LOGGER
-          echo "Setting HARMONIC_LOGGER=$HARMONIC_LOGGER"
+        if [ -n "${{ inputs.logger }}" ]; then
+          export HARMONIC_LOGGER=${{ inputs.logger }}
+          echo "Set HARMONIC_LOGGER=$HARMONIC_LOGGER"
         fi
 
-        if [ -n "${INPUT_LOG_DIRECTIVES-}" ]; then
-          export HARMONIC_LOG_DIRECTIVES=$INPUT_LOG_DIRECTIVES
-          echo "Setting HARMONIC_LOG_DIRECTIVES=$HARMONIC_LOG_DIRECTIVES"
+        if [ -n "${{ inputs.log-directives }}" ]; then
+          export HARMONIC_LOG_DIRECTIVES=${{ inputs.log-directives }}
+          echo "Set HARMONIC_LOG_DIRECTIVES=$HARMONIC_LOG_DIRECTIVES"
         fi
 
-        if [ -n "${INPUT_BACKTRACE-}" ]; then
-          export RUST_BACKTRACE=$INPUT_BACKTRACE
-          echo "Setting RUST_BACKTRACE=$RUST_BACKTRACE"
+        if [ -n "${{ inputs.backtrace }}" ]; then
+          export RUST_BACKTRACE=${{ inputs.backtrace }}
+          echo "Set RUST_BACKTRACE=$RUST_BACKTRACE"
         fi
 
-        curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}
+        curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}
 
 

--- a/action.yml
+++ b/action.yml
@@ -182,8 +182,6 @@ runs:
         export HARMONIC_NO_CONFIRM=1
         echo "Set HARMONIC_NO_CONFIRM=$HARMONIC_NO_CONFIRM"
 
-        EXEC="curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}"
-        echo "Executing \`$EXEC\`"
-        $EXEC
+        curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}
 
 

--- a/action.yml
+++ b/action.yml
@@ -152,8 +152,8 @@ runs:
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
             sleep 1
           done
-          export NIX_INSTALL_URL=0.0.0.0:8000
-          echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"
+          export NIX_INSTALL_URL=0.0.0.0:8000/nix-install.sh
+          echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL/nix-install.sh"
           export NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_URL
           echo "Set NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_UPDATE_ROOT"
           export NIX_INSTALL_FORCE_ALLOW_HTTP=1

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: Extra args to pass to the planner (prefer using structured `with:` arguments unless using a custom planner!)
     required: false
   github-token:
-    description: A Github Token so that authenticated requests can be made (set this to `${{ secrets.GITHUB_TOKEN }}`)
+    description: A Github Token so that authenticated requests can be made (set this to `secrets.GITHUB_TOKEN`)
   channels:
     description: Channel(s) to add (eg `nixpkgs=https://nixos.org/channels/nixpkgs-unstable`)
     required: false
@@ -34,7 +34,7 @@ inputs:
     description: The Nix package URL
     required: false
   extra-conf:
-    description: Extra configuration lines for `/etc/nix.conf` (includes `access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}` automatically if `github-token` is set)
+    description: Extra configuration lines for `/etc/nix.conf` (includes `access-tokens` with `secrets.GITHUB_TOKEN` automatically if `github-token` is set)
     required: false
   mac-encrypt:
     description: Force encryption on the volume (Mac only)
@@ -55,6 +55,16 @@ inputs:
   harmonic-local-root:
     description: A local `harmonic` binary root, overrides the `nix-install` setting (binaries should be named `harmonic-$ARCH`, eg. `harmonic-$x86_64-linux`)
     required: false
+  logger:
+    description: The logger to use for install (eg. `pretty`, `json`, `full`, `compact`)
+    required: false
+  log-directives:
+    description: A list of Tracing directives, comma separated (eg. `harmonic=trace`, see https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)
+    required: false
+  backtrace:
+    description: The setting for `RUST_BACKTRACE` (see https://doc.rust-lang.org/std/backtrace/index.html#environment-variables)
+    required: false
+
 
 runs:
   using: composite
@@ -127,6 +137,18 @@ runs:
         if [ -n "${INPUT_HARMONIC-LOCAL-ROOT-}" ]; then
           python -m http.server --directory install-root/ --bind 0.0.0.0 8000 &
           export NIX_INSTALL_URL=0.0.0.0:8000
+        fi
+
+        if [ -n "${INPUT_LOGGER-}" ]; then
+          export HARMONIC_LOGGER=$INPUT_LOGGER
+        fi
+
+        if [ -n "${INPUT_LOG-DIRECTIVES-}" ]; then
+          export HARMONIC_LOG_DIRECTIVES=$INPUT_LOG-DIRECTIVES
+        fi
+
+        if [ -n "${INPUT_BACKTRACE-}" ]; then
+          export RUST_BACKTRACE=$INPUT_BACKTRACE
         fi
 
         curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}

--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,9 @@ runs:
 
         if [ -n "${INPUT_HARMONIC-LOCAL-ROOT-}" ]; then
           python -m http.server --directory install-root/ --bind 0.0.0.0 8000 &
+          while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
+            sleep 1;
+          done
           export NIX_INSTALL_URL=0.0.0.0:8000
         fi
 
@@ -153,3 +156,5 @@ runs:
         fi
 
         curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}
+
+

--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,10 @@ runs:
           echo "Set RUST_BACKTRACE=$RUST_BACKTRACE"
         fi
 
+
+        export HARMONIC_NO_CONFIRM=1
+        echo "Set HARMONIC_NO_CONFIRM=$HARMONIC_NO_CONFIRM"
+
         EXEC="curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}"
         echo "Executing \`$EXEC\`"
         $EXEC

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,7 @@ runs:
           done
           export NIX_INSTALL_URL=0.0.0.0:8000/nix-install.sh
           echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL/nix-install.sh"
-          export NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_URL
+          export NIX_INSTALL_UPDATE_ROOT=http://0.0.0.0:8000/
           echo "Set NIX_INSTALL_UPDATE_ROOT=$NIX_INSTALL_UPDATE_ROOT"
           export NIX_INSTALL_FORCE_ALLOW_HTTP=1
           echo "Set NIX_INSTALL_FORCE_ALLOW_HTTP=$NIX_INSTALL_FORCE_ALLOW_HTTP"

--- a/action.yml
+++ b/action.yml
@@ -153,8 +153,10 @@ runs:
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
             sleep 1
           done
+          export NIX_INSTALL_FORCE_ALLOW_HTTP="1"
+          echo "Set NIX_INSTALL_FORCE_ALLOW_HTTP=$NIX_INSTALL_FORCE_ALLOW_HTTP"
           export NIX_INSTALL_URL=0.0.0.0:8000/nix-install.sh
-          echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL/nix-install.sh"
+          echo "Set NIX_INSTALL_URL=$NIX_INSTALL_URL"
           export NIX_INSTALL_BINARY_ROOT=http://0.0.0.0:8000/
           echo "Set NIX_INSTALL_BINARY_ROOT=$NIX_INSTALL_BINARY_ROOT"
           export NIX_INSTALL_FORCE_ALLOW_HTTP=1

--- a/action.yml
+++ b/action.yml
@@ -156,6 +156,9 @@ runs:
             sleep 1
           done
           export NIX_INSTALL_URL=0.0.0.0:8000
+          echo "Setting NIX_INSTALL_URL=$INPUT_NIX_INSTALL_URL"
+        else
+          export NIX_INSTALL_URL=$INPUT_NIX_INSTALL_URL
           echo "Setting NIX_INSTALL_URL=$NIX_INSTALL_URL"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   nix-build-group-name:
     description: The Nix build group name
     required: false
-  nix-build-build-group-id:
+  nix-build-group-id:
     description: The Nix build group GID
     required: false
   nix-build-user-prefix:
@@ -77,80 +77,80 @@ runs:
           echo "Setting HARMONIC_CHANNELS=$HARMONIC_CHANNELS"
         fi
 
-        if [ -n "${INPUT_MODIFY-PROFILE-}" ]; then
-          export HARMONIC_MODIFY_PROFILE=$INPUT_MODIFY-PROFILE
+        if [ -n "${INPUT_MODIFY_PROFILE-}" ]; then
+          export HARMONIC_MODIFY_PROFILE=$INPUT_MODIFY_PROFILE
           echo "Setting HARMONIC_MODIFY_PROFILE=$HARMONIC_MODIFY_PROFILE"
         fi
 
-        if [ -n "${INPUT_DAEMON-USER-COUNT-}" ]; then
-          export HARMONIC_DAEMON_USER_COUNT=$INPUT_DAEMON-USER-COUNT
+        if [ -n "${INPUT_DAEMON_USER_COUNT-}" ]; then
+          export HARMONIC_DAEMON_USER_COUNT=$INPUT_DAEMON_USER_COUNT
           echo "Setting HARMONIC_DAEMON_USER_COUNT=$HARMONIC_DAEMON_USER_COUNT"
         fi
 
-        if [ -n "${INPUT_NIX-BUILD-GROUP-NAME-}" ]; then
-          export HARMONIC_NIX_BUILD_GROUP_NAME=$INPUT_NIX-BUILD-GROUP-NAME
+        if [ -n "${INPUT_NIX_BUILD_GROUP_NAME-}" ]; then
+          export HARMONIC_NIX_BUILD_GROUP_NAME=$INPUT_NIX_BUILD_GROUP_NAME
           echo "Setting HARMONIC_NIX_BUILD_GROUP_NAME=$HARMONIC_NIX_BUILD_GROUP_NAME"
         fi
 
-        if [ -n "${INPUT_NIX-BUILD-BUILD-GROUP-ID-}" ]; then
-          export HARMONIC_NIX_BUILD_GROUP_ID=$INPUT_NIX-BUILD-BUILD-GROUP-ID
+        if [ -n "${INPUT_NIX_BUILD_GROUP_ID-}" ]; then
+          export HARMONIC_NIX_BUILD_GROUP_ID=$INPUT_NIX_BUILD_GROUP_ID
           echo "Setting HARMONIC_NIX_BUILD_GROUP_ID=$HARMONIC_NIX_BUILD_GROUP_ID"
         fi
 
-        if [ -n "${INPUT_NIX-BUILD-BUILD-GROUP-ID-}" ]; then
-          export HARMONIC_NIX_BUILD_USER_PREFIX=$INPUT_NIX-BUILD-BUILD-GROUP-ID
+        if [ -n "${INPUT_NIX_BUILD_GROUP_ID-}" ]; then
+          export HARMONIC_NIX_BUILD_USER_PREFIX=$INPUT_NIX_BUILD_GROUP_ID
           echo "Setting HARMONIC_NIX_BUILD_USER_PREFIX=$HARMONIC_NIX_BUILD_USER_PREFIX"
         fi
 
-        if [ -n "${INPUT_NIX-BUILD-USER-BASE-}" ]; then
-          export HARMONIC_NIX_BUILD_USER_ID_BASE=$INPUT_NIX-BUILD-USER-BASE
+        if [ -n "${INPUT_NIX_BUILD_USER_BASE-}" ]; then
+          export HARMONIC_NIX_BUILD_USER_ID_BASE=$INPUT_NIX_BUILD_USER_BASE
           echo "Setting HARMONIC_NIX_BUILD_USER_ID_BASE=$HARMONIC_NIX_BUILD_USER_ID_BASE"
         fi
 
-        if [ -n "${INPUT_NIX-PACKAGE-URL-}" ]; then
-          export HARMONIC_NIX_PACKAGE_URL=$INPUT_NIX-PACKAGE-URL
+        if [ -n "${INPUT_NIX_PACKAGE_URL-}" ]; then
+          export HARMONIC_NIX_PACKAGE_URL=$INPUT_NIX_PACKAGE_URL
           echo "Setting HARMONIC_NIX_PACKAGE_URL=$HARMONIC_NIX_PACKAGE_URL"
         fi
 
-        if [ -n "${INPUT_EXTRA-CONF-}" ]; then
-          if [ -n "${INPUT_GITHUB-TOKEN-}" ]; then
-            export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF\naccess-tokens = github.com=$INPUT_GITHUB-TOKEN"
+        if [ -n "${INPUT_EXTRA_CONF-}" ]; then
+          if [ -n "${INPUT_GITHUB_TOKEN-}" ]; then
+            export HARMONIC_EXTRA_CONF="$INPUT_EXTRA_CONF\naccess-tokens = github.com=$INPUT_GITHUB_TOKEN"
           fi
-          export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF"
+          export HARMONIC_EXTRA_CONF="$INPUT_EXTRA_CONF"
           echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
         else
           if [ -n "${INPUT_GITHUB-TOKEN-}" ]; then
-            export HARMONIC_EXTRA_CONF="access-tokens = github.com=$INPUT_GITHUB-TOKEN"
+            export HARMONIC_EXTRA_CONF="access_tokens = github.com=$INPUT_GITHUB_TOKEN"
             echo "Set HARMONIC_EXTRA_CONF=$HARMONIC_EXTRA_CONF"
           fi
         fi
 
-        if [ -n "${INPUT_MAC-ENCRYPT-}" ]; then
-          export HARMONIC_ENCRYPT=$INPUT_MAC-ENCRYPT
+        if [ -n "${INPUT_MAC_ENCRYPT-}" ]; then
+          export HARMONIC_ENCRYPT=$INPUT_MAC_ENCRYPT
           echo "Setting HARMONIC_ENCRYPT=$HARMONIC_ENCRYPT"
         fi
 
-        if [ -n "${INPUT_MAC-CASE-SENSITIVE-}" ]; then
-          export HARMONIC_CASE_SENSITIVE=$INPUT_MAC-CASE-SENSITIVE
+        if [ -n "${INPUT_MAC_CASE_SENSITIVE-}" ]; then
+          export HARMONIC_CASE_SENSITIVE=$INPUT_MAC_CASE_SENSITIVE
           echo "Setting HARMONIC_CASE_SENSITIVE=$HARMONIC_CASE_SENSITIVE"
         fi
 
-        if [ -n "${INPUT_MAC-VOLUME-LABEL-}" ]; then
-          export HARMONIC_VOLUME_LABEL=$INPUT_MAC-VOLUME-LABEL
+        if [ -n "${INPUT_MAC_VOLUME_LABEL-}" ]; then
+          export HARMONIC_VOLUME_LABEL=$INPUT_MAC_VOLUME_LABEL
           echo "Setting HARMONIC_VOLUME_LABEL=$HARMONIC_VOLUME_LABEL"
         fi
 
-        if [ -n "${INPUT_MAC-ROOT-DISK-}" ]; then
-          export HARMONIC_ROOT_DISK=$INPUT_MAC-ROOT-DISK
+        if [ -n "${INPUT_MAC_ROOT_DISK-}" ]; then
+          export HARMONIC_ROOT_DISK=$INPUT_MAC_ROOT_DISK
           echo "Setting HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
         fi
 
-        if [ -n "${INPUT_MAC-ROOT-DISK-}" ]; then
-          export HARMONIC_ROOT_DISK=$INPUT_MAC-ROOT-DISK
+        if [ -n "${INPUT_MAC_ROOT_DISK-}" ]; then
+          export HARMONIC_ROOT_DISK=$INPUT_MAC_ROOT_DISK
           echo "Setting HARMONIC_ROOT_DISK=$HARMONIC_ROOT_DISK"
         fi
 
-        if [ -n "${INPUT_HARMONIC-LOCAL-ROOT-}" ]; then
+        if [ -n "${INPUT_HARMONIC_LOCAL_ROOT-}" ]; then
           python -m http.server --directory install-root/ --bind 0.0.0.0 8000 &
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do
             sleep 1
@@ -164,8 +164,8 @@ runs:
           echo "Setting HARMONIC_LOGGER=$HARMONIC_LOGGER"
         fi
 
-        if [ -n "${INPUT_LOG-DIRECTIVES-}" ]; then
-          export HARMONIC_LOG_DIRECTIVES=$INPUT_LOG-DIRECTIVES
+        if [ -n "${INPUT_LOG_DIRECTIVES-}" ]; then
+          export HARMONIC_LOG_DIRECTIVES=$INPUT_LOG_DIRECTIVES
           echo "Setting HARMONIC_LOG_DIRECTIVES=$HARMONIC_LOG_DIRECTIVES"
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -69,8 +69,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: Install Nix
-      shell: |
+    - name: Install Nix
+      run: |
         if [ -n "${INPUT_CHANNELS-}" ]; then
           export HARMONIC_CHANNELS=$INPUT_CHANNELS
         fi

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
+      shell: bash
       run: |
         if [ -n "${INPUT_CHANNELS-}" ]; then
           export HARMONIC_CHANNELS=$INPUT_CHANNELS

--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,8 @@ runs:
           echo "Set RUST_BACKTRACE=$RUST_BACKTRACE"
         fi
 
-        curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}
+        EXEC="curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}"
+        echo "Executing \`$EXEC\`"
+        $EXEC
 
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,125 @@
+name: Harmonic
+description: Install Nix
+inputs:
+  planner:
+    description: A planner to use
+    required: false
+  extra-args:
+    description: Extra args to pass to the planner (prefer using structured `with:` arguments unless using a custom planner!)
+    required: false
+  channels:
+    description: Channel(s) to add (eg `nixpkgs=https://nixos.org/channels/nixpkgs-unstable`)
+    required: false
+  modify-profile:
+    description: Modify the user profile to automatically load nix
+    required: false
+  daemon-user-count:
+    description: Number of build users to create
+    required: false
+  nix-build-group-name:
+    description: The Nix build group name
+    required: false
+  nix-build-build-group-id:
+    description: The Nix build group GID
+    required: false
+  nix-build-user-prefix:
+    description: The Nix build user prefix (user numbers will be postfixed)
+    required: false
+  nix-build-user-base:
+    description: The Nix build user base UID (ascending)
+    required: false
+  nix-package-url:
+    description: The Nix package URL
+    required: false
+  extra-conf:
+    description: Extra configuration lines for `/etc/nix.conf` (includes `access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}` automatically)
+    required: false
+  mac-encrypt:
+    description: Force encryption on the volume (Mac only)
+    required: false
+  mac-case-sensitive:
+    description: Use a case sensitive volume (Mac only)
+    required: false
+  mac-volume-label:
+    description: The label for the created APFS volume (Mac only)
+    required: false
+  mac-root-disk:
+    description: The root disk of the target (Mac only)
+    required: false
+  nix-install-url:
+    description: A URL pointing to a harmonic `nix-install.sh` script
+    required: true
+    default: https://install.determinate.systems/nix
+  harmonic-local-root:
+    description: A local `harmonic` binary root, overrides the `nix-install` setting (binaries should be named `harmonic-$ARCH`, eg. `harmonic-$x86_64-linux`)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - run: Install Nix
+      shell: |
+        if [ -n "${INPUT_CHANNELS-}" ]; then
+          export HARMONIC_CHANNELS=$INPUT_CHANNELS
+        fi
+
+        if [ -n "${INPUT_MODIFY-PROFILE-}" ]; then
+          export HARMONIC_MODIFY_PROFILE=$INPUT_MODIFY-PROFILE
+        fi
+
+        if [ -n "${INPUT_DAEMON-USER-COUNT-}" ]; then
+          export HARMONIC_DAEMON_USER_COUNT=$INPUT_DAEMON-USER-COUNT
+        fi
+
+        if [ -n "${INPUT_NIX-BUILD-GROUP-NAME-}" ]; then
+          export HARMONIC_NIX_BUILD_GROUP_NAME=$INPUT_NIX-BUILD-GROUP-NAME
+        fi
+
+        if [ -n "${INPUT_NIX-BUILD-BUILD-GROUP-ID-}" ]; then
+          export HARMONIC_NIX_BUILD_GROUP_ID=$INPUT_NIX-BUILD-BUILD-GROUP-ID
+        fi
+
+        if [ -n "${INPUT_NIX-BUILD-BUILD-GROUP-ID-}" ]; then
+          export HARMONIC_NIX_BUILD_USER_PREFIX=$INPUT_NIX-BUILD-BUILD-GROUP-ID
+        fi
+
+        if [ -n "${INPUT_NIX-BUILD-USER-BASE-}" ]; then
+          export HARMONIC_NIX_BUILD_USER_ID_BASE=$INPUT_NIX-BUILD-USER-BASE
+        fi
+
+        if [ -n "${INPUT_NIX-PACKAGE-URL-}" ]; then
+          export HARMONIC_NIX_PACKAGE_URL=$INPUT_NIX-PACKAGE-URL
+        fi
+
+        if [ -n "${INPUT_EXTRA-CONF-}" ]; then
+          export HARMONIC_EXTRA_CONF="$INPUT_EXTRA-CONF\naccess-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        else
+          export HARMONIC_EXTRA_CONF="access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+        fi
+
+        if [ -n "${INPUT_MAC-ENCRYPT-}" ]; then
+          export HARMONIC_ENCRYPT=$INPUT_MAC-ENCRYPT
+        fi
+
+        if [ -n "${INPUT_MAC-CASE-SENSITIVE-}" ]; then
+          export HARMONIC_CASE_SENSITIVE=$INPUT_MAC-CASE-SENSITIVE
+        fi
+
+        if [ -n "${INPUT_MAC-VOLUME-LABEL-}" ]; then
+          export HARMONIC_VOLUME_LABEL=$INPUT_MAC-VOLUME-LABEL
+        fi
+
+        if [ -n "${INPUT_MAC-ROOT-DISK-}" ]; then
+          export HARMONIC_ROOT_DISK=$INPUT_MAC-ROOT-DISK
+        fi
+
+        if [ -n "${INPUT_MAC-ROOT-DISK-}" ]; then
+          export HARMONIC_ROOT_DISK=$INPUT_MAC-ROOT-DISK
+        fi
+
+        if [ -n "${INPUT_HARMONIC-LOCAL-ROOT-}" ]; then
+          python -m http.server --directory install-root/ --bind 0.0.0.0 8000 &
+          export NIX_INSTALL_URL=0.0.0.0:8000
+        fi
+
+        curl --retry 20 --retry-max-time 120 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}

--- a/action.yml
+++ b/action.yml
@@ -179,7 +179,7 @@ runs:
         fi
 
 
-        export HARMONIC_NO_CONFIRM=1
+        export HARMONIC_NO_CONFIRM=true
         echo "Set HARMONIC_NO_CONFIRM=$HARMONIC_NO_CONFIRM"
 
         curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${{ inputs.planner }} ${{ inputs.extra-args }}

--- a/action.yml
+++ b/action.yml
@@ -122,4 +122,4 @@ runs:
           export NIX_INSTALL_URL=0.0.0.0:8000
         fi
 
-        curl --retry 20 --retry-max-time 120 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}
+        curl --retry 20 -L $NIX_INSTALL_URL | sh -s -- install ${INPUT_PLANNER-} ${INPUT_EXTRA-ARGS-}

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
     required: true
     default: https://install.determinate.systems/nix
   local-root:
-    description: A local `harmonic` binary root, overrides the `nix-install` setting (binaries should be named `harmonic-$ARCH`, eg. `harmonic-$x86_64-linux`)
+    description: A local `harmonic` binary root, overrides the `nix-install` setting (binaries should be named `harmonic-$ARCH`, eg. `harmonic-x86_64-linux`)
     required: false
   logger:
     description: The logger to use for install (eg. `pretty`, `json`, `full`, `compact`)
@@ -185,7 +185,6 @@ runs:
           export RUST_BACKTRACE=${{ inputs.backtrace }}
           echo "Set RUST_BACKTRACE=$RUST_BACKTRACE"
         fi
-
 
         export HARMONIC_NO_CONFIRM=true
         echo "Set HARMONIC_NO_CONFIRM=$HARMONIC_NO_CONFIRM"

--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,12 @@ runs:
         fi
 
         if [ -n "${{ inputs.local-root }}" ]; then
-          python -m http.server --directory ${{ inputs.local-root }} --bind 0.0.0.0 8000 &
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            export PYTHON="python3"
+          else
+            export PYTHON="python"
+          fi
+          $PYTHON -m http.server --directory ${{ inputs.local-root }} --bind 0.0.0.0 8000 &
           export HTTP_PID=$!
           echo "Started simple http server for ${{ inputs.local-root }} on 0.0.0.0:8000"
           while (! (: </dev/tcp/localhost/8000) &> /dev/null); do

--- a/nix-install.sh
+++ b/nix-install.sh
@@ -21,8 +21,8 @@ fi
 
 set -u
 
-# If NIX_INSTALL_UPDATE_ROOT is unset or empty, default it.
-NIX_INSTALL_UPDATE_ROOT="${NIX_INSTALL_UPDATE_ROOT:-https://install.determinate.systems/nix}"
+# If NIX_INSTALL_BINARY_ROOT is unset or empty, default it.
+NIX_INSTALL_BINARY_ROOT="${NIX_INSTALL_BINARY_ROOT:-https://install.determinate.systems/nix}"
 
 main() {
     downloader --check
@@ -44,7 +44,7 @@ main() {
             ;;
     esac
 
-    local _url="${NIX_INSTALL_OVERRIDE_URL-${NIX_INSTALL_UPDATE_ROOT}/harmonic-${_arch}${_ext}}"
+    local _url="${NIX_INSTALL_OVERRIDE_URL-${NIX_INSTALL_BINARY_ROOT}/harmonic-${_arch}${_ext}}"
 
     local _dir
     if ! _dir="$(ensure mktemp -d)"; then

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -41,7 +41,7 @@ impl CreateDirectory {
             let metadata = tokio::fs::metadata(path)
                 .await
                 .map_err(|e| ActionError::GettingMetadata(path.to_path_buf(), e))?;
-            if metadata.is_dir() || metadata.is_symlink() {
+            if metadata.is_dir() {
                 tracing::debug!(
                     "Creating directory `{}` already complete, skipping",
                     path.display(),

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -40,7 +40,7 @@ impl CreateDirectory {
             let metadata = tokio::fs::metadata(path)
                 .await
                 .map_err(|e| ActionError::GettingMetadata(path.to_path_buf(), e))?;
-            if metadata.is_dir() {
+            if metadata.is_dir() || metadata.is_symlink() {
                 tracing::debug!(
                     "Creating directory `{}` already complete, skipping",
                     path.display(),

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -67,6 +67,7 @@ impl Action for CreateFile {
         user = self.user,
         group = self.group,
         mode = self.mode.map(|v| tracing::field::display(format!("{:#o}", v))),
+        buf = tracing::field::Empty,
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
@@ -77,6 +78,11 @@ impl Action for CreateFile {
             buf,
             force: _,
         } = self;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            let span = tracing::Span::current();
+            span.record("buf", &buf);
+        }
 
         let mut options = OpenOptions::new();
         options.create_new(true).write(true).read(true);

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -1,4 +1,5 @@
 use nix::unistd::{chown, Group, User};
+use tracing::{span, Span};
 
 use std::path::{Path, PathBuf};
 use tokio::{
@@ -58,17 +59,31 @@ impl Action for CreateFile {
     fn tracing_synopsis(&self) -> String {
         format!("Create or overwrite file `{}`", self.path.display())
     }
+
+    fn tracing_span(&self) -> Span {
+        let span = span!(
+            tracing::Level::DEBUG,
+            "create_file",
+            path = tracing::field::display(self.path.display()),
+            user = self.user,
+            group = self.group,
+            mode = self
+                .mode
+                .map(|v| tracing::field::display(format!("{:#o}", v))),
+            buf = tracing::field::Empty,
+        );
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            span.record("buf", &self.buf);
+        }
+        span
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        path = %self.path.display(),
-        user = self.user,
-        group = self.group,
-        mode = self.mode.map(|v| tracing::field::display(format!("{:#o}", v))),
-        buf = tracing::field::Empty,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             path,
@@ -141,12 +156,7 @@ impl Action for CreateFile {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        path = %self.path.display(),
-        user = self.user,
-        group = self.group,
-        mode = self.mode.map(|v| tracing::field::display(format!("{:#o}", v))),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             path,

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -1,4 +1,5 @@
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::ActionError;
 use crate::execute_command;
@@ -37,10 +38,16 @@ impl Action for CreateGroup {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        user = self.name,
-        gid = self.gid,
-    ))]
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "create_group",
+            user = self.name,
+            gid = self.gid,
+        )
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { name, gid } = self;
 
@@ -108,10 +115,7 @@ impl Action for CreateGroup {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        user = self.name,
-        gid = self.gid,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { name, gid: _ } = self;
 

--- a/src/action/base/create_or_append_file.rs
+++ b/src/action/base/create_or_append_file.rs
@@ -67,6 +67,7 @@ impl Action for CreateOrAppendFile {
         user = self.user,
         group = self.group,
         mode = self.mode.map(|v| tracing::field::display(format!("{:#o}", v))),
+        buf = tracing::field::Empty,
     ))]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
@@ -76,6 +77,11 @@ impl Action for CreateOrAppendFile {
             mode,
             buf,
         } = self;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            let span = tracing::Span::current();
+            span.record("buf", &buf);
+        }
 
         let mut file = OpenOptions::new()
             .create(true)

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -1,4 +1,5 @@
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::ActionError;
 use crate::execute_command;
@@ -38,6 +39,18 @@ impl Action for CreateUser {
             self.name, self.uid, self.groupname, self.gid
         )
     }
+
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "create_user",
+            user = self.name,
+            uid = self.uid,
+            groupname = self.groupname,
+            gid = self.gid,
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
             self.tracing_synopsis(),
@@ -47,12 +60,7 @@ impl Action for CreateUser {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        user = self.name,
-        uid = self.uid,
-        groupname = self.groupname,
-        gid = self.gid,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             name,
@@ -231,11 +239,7 @@ impl Action for CreateUser {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        user = self.name,
-        uid = self.uid,
-        gid = self.gid,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             name,

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use bytes::Buf;
 use reqwest::Url;
+use tracing::{span, Span};
 
 use crate::action::{Action, ActionDescription, ActionError, StatefulAction};
 
@@ -31,14 +32,20 @@ impl Action for FetchAndUnpackNix {
         format!("Fetch `{}` to `{}`", self.url, self.dest.display())
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "fetch_and_unpack_nix",
+            url = tracing::field::display(&self.url),
+            dest = tracing::field::display(self.dest.display()),
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        url = %self.url,
-        dest = %self.dest.display(),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { url, dest } = self;
 
@@ -66,10 +73,7 @@ impl Action for FetchAndUnpackNix {
         vec![/* Deliberately empty -- this is a noop */]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        url = %self.url,
-        dest = %self.dest.display(),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { url: _, dest: _ } = self;
 

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use tracing::{span, Span};
+
 use crate::action::{Action, ActionDescription, ActionError, StatefulAction};
 
 const DEST: &str = "/nix/store";
@@ -27,6 +29,15 @@ impl Action for MoveUnpackedNix {
         "Move the downloaded Nix into `/nix`".to_string()
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "mount_unpacked_nix",
+            src = tracing::field::display(self.src.display()),
+            dest = DEST,
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
             format!("Move the downloaded Nix into `/nix`"),
@@ -37,10 +48,7 @@ impl Action for MoveUnpackedNix {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        src = %self.src.display(),
-        dest = DEST,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { src } = self;
 
@@ -73,10 +81,7 @@ impl Action for MoveUnpackedNix {
         vec![/* Deliberately empty -- this is a noop */]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        src = %self.src.display(),
-        dest = DEST,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         // Noop
         Ok(())

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -6,6 +6,7 @@ use crate::{
 use glob::glob;
 
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{Action, ActionDescription};
 
@@ -31,13 +32,19 @@ impl Action for SetupDefaultProfile {
         "Setup the default Nix profile".to_string()
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "setup_default_profile",
+            channels = self.channels.join(","),
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        channels = %self.channels.join(","),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { channels } = self;
 
@@ -156,9 +163,7 @@ impl Action for SetupDefaultProfile {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        channels = %self.channels.join(","),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         std::env::remove_var("NIX_SSL_CERT_FILE");
 

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -161,7 +161,7 @@ impl Action for ConfigureNix {
                 async move {
                     place_channel_configuration
                         .try_execute()
-                        .instrument(place_channel_configuration)
+                        .instrument(place_channel_configuration_span)
                         .await
                 },
             )?;

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -103,44 +103,65 @@ impl Action for ConfigureNix {
         } = self;
 
         if let Some(configure_shell_profile) = configure_shell_profile {
-            let span = tracing::Span::current().clone();
-            let (span2, span3, span4) = (span.clone(), span.clone(), span.clone());
+            let setup_default_profile_span = tracing::Span::current().clone();
+            let (
+                place_nix_configuration_span,
+                place_channel_configuration_span,
+                configure_shell_profile_span,
+            ) = (
+                setup_default_profile_span.clone(),
+                setup_default_profile_span.clone(),
+                setup_default_profile_span.clone(),
+            );
             tokio::try_join!(
-                async move { setup_default_profile.try_execute().instrument(span).await },
+                async move {
+                    setup_default_profile
+                        .try_execute()
+                        .instrument(setup_default_profile_span)
+                        .await
+                },
                 async move {
                     place_nix_configuration
                         .try_execute()
-                        .instrument(span2)
+                        .instrument(place_nix_configuration_span)
                         .await
                 },
                 async move {
                     place_channel_configuration
                         .try_execute()
-                        .instrument(span3)
+                        .instrument(place_channel_configuration_span)
                         .await
                 },
                 async move {
                     configure_shell_profile
                         .try_execute()
-                        .instrument(span4)
+                        .instrument(configure_shell_profile_span)
                         .await
                 },
             )?;
         } else {
-            let span = tracing::Span::current().clone();
-            let (span2, span3) = (span.clone(), span.clone());
+            let place_channel_configuration_span = tracing::Span::current().clone();
+            let (setup_default_profile_span, place_nix_configuration_span) = (
+                place_channel_configuration_span.clone(),
+                place_channel_configuration_span.clone(),
+            );
             tokio::try_join!(
-                async move { setup_default_profile.try_execute().instrument(span).await },
+                async move {
+                    setup_default_profile
+                        .try_execute()
+                        .instrument(setup_default_profile_span)
+                        .await
+                },
                 async move {
                     place_nix_configuration
                         .try_execute()
-                        .instrument(span2)
+                        .instrument(place_nix_configuration_span)
                         .await
                 },
                 async move {
                     place_channel_configuration
                         .try_execute()
-                        .instrument(span3)
+                        .instrument(place_channel_configuration)
                         .await
                 },
             )?;

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -31,7 +31,7 @@ impl CreateNixTree {
         let mut create_directories = Vec::default();
         for path in PATHS {
             // We use `create_dir` over `create_dir_all` to ensure we always set permissions right
-            create_directories.push(CreateDirectory::plan(path, None, None, 0o0755, false).await?)
+            create_directories.push(CreateDirectory::plan(path, None, None, 0o0755, true).await?)
         }
 
         Ok(Self { create_directories }.into())

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -1,3 +1,5 @@
+use tracing::{span, Span};
+
 use crate::action::base::CreateDirectory;
 use crate::action::{Action, ActionDescription, ActionError, StatefulAction};
 
@@ -43,6 +45,10 @@ impl CreateNixTree {
 impl Action for CreateNixTree {
     fn tracing_synopsis(&self) -> String {
         "Create a directory tree in `/nix`".to_string()
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "create_nix_tree",)
     }
 
     fn execute_description(&self) -> Vec<ActionDescription> {

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -31,7 +31,7 @@ impl CreateNixTree {
         let mut create_directories = Vec::default();
         for path in PATHS {
             // We use `create_dir` over `create_dir_all` to ensure we always set permissions right
-            create_directories.push(CreateDirectory::plan(path, None, None, 0o0755, true).await?)
+            create_directories.push(CreateDirectory::plan(path, None, None, 0o0755, false).await?)
         }
 
         Ok(Self { create_directories }.into())

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -1,3 +1,5 @@
+use tracing::{span, Span};
+
 use crate::action::base::{CreateDirectory, CreateFile};
 use crate::action::{Action, ActionDescription, ActionError, StatefulAction};
 
@@ -48,6 +50,10 @@ impl PlaceNixConfiguration {
 impl Action for PlaceNixConfiguration {
     fn tracing_synopsis(&self) -> String {
         format!("Place the Nix configuration in `{NIX_CONF}`")
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "place_nix_configuration",)
     }
 
     fn execute_description(&self) -> Vec<ActionDescription> {

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -1,3 +1,5 @@
+use tracing::{span, Span};
+
 use super::{CreateNixTree, CreateUsersAndGroups};
 use crate::{
     action::{
@@ -46,6 +48,10 @@ impl ProvisionNix {
 impl Action for ProvisionNix {
     fn tracing_synopsis(&self) -> String {
         "Provision Nix".to_string()
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "provision_nix",)
     }
 
     fn execute_description(&self) -> Vec<ActionDescription> {

--- a/src/action/darwin/bootstrap_apfs_volume.rs
+++ b/src/action/darwin/bootstrap_apfs_volume.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
@@ -32,13 +33,19 @@ impl Action for BootstrapApfsVolume {
         format!("Bootstrap and kickstart `{}`", self.path.display())
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "bootstrap_volume",
+            path = %self.path.display(),
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        path = %self.path.display(),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { path } = self;
 
@@ -70,9 +77,7 @@ impl Action for BootstrapApfsVolume {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        path = %self.path.display(),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { path } = self;
 

--- a/src/action/darwin/create_apfs_volume.rs
+++ b/src/action/darwin/create_apfs_volume.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
@@ -41,15 +42,21 @@ impl Action for CreateApfsVolume {
         )
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "create_volume",
+            disk = %self.disk.display(),
+            name = %self.name,
+            case_sensitive = %self.case_sensitive,
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        disk = %self.disk.display(),
-        name = %self.name,
-        case_sensitive = %self.case_sensitive,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             disk,
@@ -91,11 +98,7 @@ impl Action for CreateApfsVolume {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        disk = %self.disk.display(),
-        name = %self.name,
-        case_sensitive = %self.case_sensitive,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             disk: _,

--- a/src/action/darwin/create_nix_volume.rs
+++ b/src/action/darwin/create_nix_volume.rs
@@ -11,6 +11,7 @@ use std::{
     time::Duration,
 };
 use tokio::process::Command;
+use tracing::{span, Span};
 
 pub const NIX_VOLUME_MOUNTD_DEST: &str = "/Library/LaunchDaemons/org.nixos.darwin-store.plist";
 
@@ -143,6 +144,15 @@ impl Action for CreateNixVolume {
         )
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "create_apfs_volume",
+            disk = tracing::field::display(self.disk.display()),
+            name = self.name
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         let Self {
             disk: _, name: _, ..
@@ -150,7 +160,7 @@ impl Action for CreateNixVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(destination,))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self {
             disk: _,
@@ -213,7 +223,7 @@ impl Action for CreateNixVolume {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(disk, name))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             disk: _,

--- a/src/action/darwin/create_synthetic_objects.rs
+++ b/src/action/darwin/create_synthetic_objects.rs
@@ -1,4 +1,5 @@
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::execute_command;
 
@@ -22,6 +23,10 @@ impl Action for CreateSyntheticObjects {
         "Create objects defined in `/etc/synthetic.conf`".to_string()
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "create_synthetic_objects",)
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
             self.tracing_synopsis(),
@@ -29,7 +34,7 @@ impl Action for CreateSyntheticObjects {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         // Yup we literally call both and ignore the error! Reasoning: https://github.com/NixOS/nix/blob/95331cb9c99151cbd790ceb6ddaf49fc1c0da4b3/scripts/create-darwin-volume.sh#L261
         execute_command(
@@ -59,7 +64,7 @@ impl Action for CreateSyntheticObjects {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         // Yup we literally call both and ignore the error! Reasoning: https://github.com/NixOS/nix/blob/95331cb9c99151cbd790ceb6ddaf49fc1c0da4b3/scripts/create-darwin-volume.sh#L261
         execute_command(

--- a/src/action/darwin/enable_ownership.rs
+++ b/src/action/darwin/enable_ownership.rs
@@ -2,6 +2,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
@@ -34,13 +35,19 @@ impl Action for EnableOwnership {
         format!("Enable ownership on {}", self.path.display())
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "enable_ownership",
+            path = %self.path.display(),
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        path = %self.path.display(),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { path } = self;
 
@@ -79,9 +86,7 @@ impl Action for EnableOwnership {
         vec![]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        path = %self.path.display(),
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         // noop
         Ok(())

--- a/src/action/darwin/encrypt_apfs_volume.rs
+++ b/src/action/darwin/encrypt_apfs_volume.rs
@@ -7,6 +7,7 @@ use crate::{
 use rand::Rng;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
+use tracing::{span, Span};
 
 /**
 Encrypt an APFS volume
@@ -40,6 +41,14 @@ impl Action for EncryptApfsVolume {
             "Encrypt volume `{}` on disk `{}`",
             self.name,
             self.disk.display()
+        )
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "encrypt_volume",
+            disk = tracing::field::display(self.disk.display()),
         )
     }
 

--- a/src/action/darwin/kickstart_launchctl_service.rs
+++ b/src/action/darwin/kickstart_launchctl_service.rs
@@ -1,4 +1,5 @@
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
@@ -28,13 +29,19 @@ impl Action for KickstartLaunchctlService {
         format!("Kickstart the launchctl unit `{unit}`")
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "kickstart_launchctl_service",
+            unit = %self.unit,
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        unit = %self.unit,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { unit } = self;
 
@@ -56,9 +63,7 @@ impl Action for KickstartLaunchctlService {
         vec![]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        unit = %self.unit,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         // noop
         Ok(())

--- a/src/action/darwin/unmount_apfs_volume.rs
+++ b/src/action/darwin/unmount_apfs_volume.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
@@ -34,14 +35,20 @@ impl Action for UnmountApfsVolume {
         format!("Unmount the `{}` APFS volume", self.name)
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "unmount_volume",
+            disk = tracing::field::display(self.disk.display()),
+            name = self.name,
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        disk = %self.disk.display(),
-        name = %self.name,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { disk: _, name } = self;
 
@@ -62,10 +69,7 @@ impl Action for UnmountApfsVolume {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        disk = %self.disk.display(),
-        name = %self.name,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { disk: _, name } = self;
 

--- a/src/action/linux/configure_nix_daemon_service.rs
+++ b/src/action/linux/configure_nix_daemon_service.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use target_lexicon::OperatingSystem;
 use tokio::fs::remove_file;
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
@@ -50,6 +51,11 @@ impl Action for ConfigureNixDaemonService {
     fn tracing_synopsis(&self) -> String {
         "Configure Nix daemon related settings with systemd".to_string()
     }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "configure_nix_daemon",)
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
             self.tracing_synopsis(),

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -1,4 +1,5 @@
 use tokio::process::Command;
+use tracing::{span, Span};
 
 use crate::action::{ActionError, ActionState, StatefulAction};
 use crate::execute_command;
@@ -32,13 +33,19 @@ impl Action for StartSystemdUnit {
         format!("Enable (and start) the systemd unit {}", self.unit)
     }
 
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "start_systemd_unit",
+            unit = %self.unit,
+        )
+    }
+
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        unit = %self.unit,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let Self { unit, .. } = self;
 
@@ -64,9 +71,7 @@ impl Action for StartSystemdUnit {
         )]
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
-        unit = %self.unit,
-    ))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { unit, .. } = self;
 

--- a/src/cli/arg/instrumentation.rs
+++ b/src/cli/arg/instrumentation.rs
@@ -38,8 +38,8 @@ pub struct Instrumentation {
     /// Tracing directives
     ///
     /// See https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
-    #[clap(long, global = true, env = "HARMONIC_LOG_DIRECTIVES", value_delimiter = ',', num_args = 0..)]
-    pub log_directive: Vec<Directive>,
+    #[clap(long = "log-directive", global = true, env = "HARMONIC_LOG_DIRECTIVES", value_delimiter = ',', num_args = 0..)]
+    pub log_directives: Vec<Directive>,
 }
 
 impl<'a> Instrumentation {

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -47,7 +47,7 @@ pub struct Install {
 
 #[async_trait::async_trait]
 impl CommandExecute for Install {
-    #[tracing::instrument(level = "debug", skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             no_confirm,

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -9,6 +9,7 @@ use crate::{
     error::HasExpectedErrors,
     plan::RECEIPT_LOCATION,
     planner::Planner,
+    settings::CommonSettings,
     BuiltinPlanner, InstallPlan,
 };
 use clap::{ArgAction, Parser};
@@ -29,6 +30,9 @@ pub struct Install {
         global = true
     )]
     pub no_confirm: bool,
+
+    #[clap(flatten)]
+    pub settings: CommonSettings,
 
     #[clap(
         long,
@@ -53,6 +57,7 @@ impl CommandExecute for Install {
             no_confirm,
             plan,
             planner,
+            settings,
             explain,
         } = self;
 
@@ -97,7 +102,7 @@ impl CommandExecute for Install {
                 serde_json::from_str(&install_plan_string)?
             },
             (None, None) => {
-                let builtin_planner = BuiltinPlanner::default()
+                let builtin_planner = BuiltinPlanner::from_common_settings(settings)
                     .await
                     .map_err(|e| eyre::eyre!(e))?;
                 let res = builtin_planner.plan().await;

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -42,7 +42,7 @@ pub struct Uninstall {
 
 #[async_trait::async_trait]
 impl CommandExecute for Uninstall {
-    #[tracing::instrument(level = "debug", skip_all, fields())]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             no_confirm,

--- a/src/planner/linux/multi.rs
+++ b/src/planner/linux/multi.rs
@@ -11,6 +11,7 @@ use crate::{
     Action, BuiltinPlanner,
 };
 use std::{collections::HashMap, path::Path};
+use tokio::process::Command;
 
 /// A planner for Linux multi-user installs
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -37,7 +38,7 @@ impl Planner for LinuxMulti {
         }
 
         // For now, we don't try to repair the user's Nix install or anything special.
-        if let Ok(_) = tokio::process::Command::new("nix-env")
+        if let Ok(_) = Command::new("nix-env")
             .arg("--version")
             .stdin(std::process::Stdio::null())
             .status()

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -101,7 +101,7 @@ impl Planner for SteamDeck {
 
     async fn plan(&self) -> Result<Vec<StatefulAction<Box<dyn Action>>>, PlannerError> {
         let persistence = &self.persistence;
-        if persistence.is_absolute() {
+        if !persistence.is_absolute() {
             return Err(PlannerError::Custom(Box::new(
                 SteamDeckError::AbsolutePathRequired(self.persistence.clone()),
             )));

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -255,6 +255,6 @@ impl Into<BuiltinPlanner> for SteamDeck {
 
 #[derive(thiserror::Error, Debug)]
 enum SteamDeckError {
-    #[error("`{0}` is not an absolute path, bind mounts require an absolute path and it cannot be canonicalized during planning")]
+    #[error("`{0}` is not an path that can be canonicalized into an absolute path, bind mounts require an absolute path")]
     AbsolutePathRequired(PathBuf),
 }

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -255,6 +255,6 @@ impl Into<BuiltinPlanner> for SteamDeck {
 
 #[derive(thiserror::Error, Debug)]
 enum SteamDeckError {
-    #[error("`{0}` is not an path that can be canonicalized into an absolute path, bind mounts require an absolute path")]
+    #[error("`{0}` is not a path that can be canonicalized into an absolute path, bind mounts require an absolute path")]
     AbsolutePathRequired(PathBuf),
 }

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -203,6 +203,10 @@ impl Planner for SteamDeck {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
+            CreateDirectory::plan("/home/nix", None, None, 0o0755, true)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
             nix_directory_unit.boxed(),
             create_bind_mount_unit.boxed(),
             ensure_symlinked_units_resolve_unit.boxed(),

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -203,10 +203,6 @@ impl Planner for SteamDeck {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            CreateDirectory::plan("/home/nix", None, None, 0o0755, true)
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
             nix_directory_unit.boxed(),
             create_bind_mount_unit.boxed(),
             ensure_symlinked_units_resolve_unit.boxed(),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -82,7 +82,7 @@ use std::collections::HashMap;
 use crate::{
     action::{ActionError, StatefulAction},
     error::HasExpectedErrors,
-    settings::InstallSettingsError,
+    settings::{CommonSettings, InstallSettingsError},
     Action, HarmonicError, InstallPlan,
 };
 
@@ -142,6 +142,16 @@ impl BuiltinPlanner {
             },
             _ => Err(PlannerError::UnsupportedArchitecture(target_lexicon::HOST)),
         }
+    }
+
+    pub async fn from_common_settings(settings: CommonSettings) -> Result<Self, PlannerError> {
+        let mut built = Self::default().await?;
+        match &mut built {
+            BuiltinPlanner::LinuxMulti(inner) => inner.settings = settings,
+            BuiltinPlanner::DarwinMulti(inner) => inner.settings = settings,
+            BuiltinPlanner::SteamDeck(inner) => inner.settings = settings,
+        }
+        Ok(built)
     }
 
     pub async fn plan(self) -> Result<InstallPlan, HarmonicError> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,14 +32,16 @@ Settings which only apply to certain [`Planner`](crate::planner::Planner)s shoul
 pub struct CommonSettings {
     /// Channel(s) to add
     #[cfg_attr(
-        feature = "cli",clap(
-        long,
-        value_parser,
-        name = "channel",
-        action = clap::ArgAction::Append,
-        env = "HARMONIC_CHANNEL",
-        default_value = "nixpkgs=https://nixos.org/channels/nixpkgs-unstable",
-    ))]
+        feature = "cli",
+        clap(
+            long,
+            value_parser,
+            name = "channel",
+            action = clap::ArgAction::Append,
+            env = "HARMONIC_CHANNELS",
+            default_value = "nixpkgs=https://nixos.org/channels/nixpkgs-unstable",
+        )
+    )]
     pub(crate) channels: Vec<ChannelValue>,
 
     /// Modify the user profile to automatically load nix

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -61,26 +61,44 @@ pub struct CommonSettings {
     /// Number of build users to create
     #[cfg_attr(
         feature = "cli",
-        clap(long, default_value = "32", env = "HARMONIC_DAEMON_USER_COUNT")
+        clap(
+            long,
+            default_value = "32",
+            env = "HARMONIC_DAEMON_USER_COUNT",
+            global = true
+        )
     )]
     pub(crate) daemon_user_count: usize,
 
     /// The Nix build group name
     #[cfg_attr(
         feature = "cli",
-        clap(long, default_value = "nixbld", env = "HARMONIC_NIX_BUILD_GROUP_NAME")
+        clap(
+            long,
+            default_value = "nixbld",
+            env = "HARMONIC_NIX_BUILD_GROUP_NAME",
+            global = true
+        )
     )]
     pub(crate) nix_build_group_name: String,
 
     /// The Nix build group GID
     #[cfg_attr(
         feature = "cli",
-        clap(long, default_value_t = 3000, env = "HARMONIC_NIX_BUILD_GROUP_ID")
+        clap(
+            long,
+            default_value_t = 3000,
+            env = "HARMONIC_NIX_BUILD_GROUP_ID",
+            global = true
+        )
     )]
     pub(crate) nix_build_group_id: usize,
 
     /// The Nix build user prefix (user numbers will be postfixed)
-    #[cfg_attr(feature = "cli", clap(long, env = "HARMONIC_NIX_BUILD_USER_PREFIX"))]
+    #[cfg_attr(
+        feature = "cli",
+        clap(long, env = "HARMONIC_NIX_BUILD_USER_PREFIX", global = true)
+    )]
     #[cfg_attr(
         all(target_os = "macos", feature = "cli"),
         clap(default_value = "_nixbld")
@@ -92,7 +110,10 @@ pub struct CommonSettings {
     pub(crate) nix_build_user_prefix: String,
 
     /// The Nix build user base UID (ascending)
-    #[cfg_attr(feature = "cli", clap(long, env = "HARMONIC_NIX_BUILD_USER_ID_BASE"))]
+    #[cfg_attr(
+        feature = "cli",
+        clap(long, env = "HARMONIC_NIX_BUILD_USER_ID_BASE", global = true)
+    )]
     #[cfg_attr(all(target_os = "macos", feature = "cli"), clap(default_value_t = 300))]
     #[cfg_attr(
         all(target_os = "linux", feature = "cli"),
@@ -101,7 +122,10 @@ pub struct CommonSettings {
     pub(crate) nix_build_user_id_base: usize,
 
     /// The Nix package URL
-    #[cfg_attr(feature = "cli", clap(long, env = "HARMONIC_NIX_PACKAGE_URL"))]
+    #[cfg_attr(
+        feature = "cli",
+        clap(long, env = "HARMONIC_NIX_PACKAGE_URL", global = true)
+    )]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86_64", feature = "cli"),
         clap(
@@ -129,7 +153,7 @@ pub struct CommonSettings {
     pub(crate) nix_package_url: Url,
 
     /// Extra configuration lines for `/etc/nix.conf`
-    #[cfg_attr(feature = "cli", clap(long, env = "HARMONIC_EXTRA_CONF"))]
+    #[cfg_attr(feature = "cli", clap(long, action = ArgAction::Set, num_args = 0.., value_delimiter = ',', env = "HARMONIC_EXTRA_CONF", global = true))]
     pub extra_conf: Vec<String>,
 
     /// If Harmonic should forcibly recreate files it finds existing


### PR DESCRIPTION
Add a Github action and some docs.

Adds some additional checks in CI to ensure things are fully stopped.

Also adds a `--log-directive` flag globally which can be used to do *roughly* what setting `RUST_LOG` does but with some validation and user approach-ability.

Also tweaks `harmonic install` to handle arguments since I figured it out and the action needed it.

Increases the granularity of some logs.

Ended up way bigger than I expected, sorry.