### PR TITLE
Minimize deps with cargo machete

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags=["--cfg", "tracing_unstable", "--cfg", "tokio_unstable"]
+rustflags=["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,122 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
-dependencies = [
- "async-lock",
- "autocfg",
- "concurrent-queue",
- "futures-lite",
- "libc",
- "log",
- "parking",
- "polling",
- "slab",
- "socket2",
- "waker-fn",
- "windows-sys",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
-dependencies = [
- "event-listener",
- "futures-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-tar"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c49359998a76e32ef6e870dbc079ebad8f1e53e8441c5dd39d27b44493fe331"
-dependencies = [
- "async-std",
- "filetime",
- "libc",
- "pin-project",
- "redox_syscall",
- "xattr",
-]
-
-[[package]]
-name = "async-task"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
-
-[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,12 +36,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -202,20 +80,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "blocking"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
-]
 
 [[package]]
 name = "bumpalo"
@@ -345,54 +209,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "futures-core",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "ctor"
@@ -570,12 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,15 +397,6 @@ checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -628,28 +433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
-name = "futures"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -657,49 +446,6 @@ name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
-
-[[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -719,16 +465,10 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -766,18 +506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,18 +528,14 @@ dependencies = [
 name = "harmonic"
 version = "0.0.0-unreleased"
 dependencies = [
- "async-tar",
  "async-trait",
  "atty",
  "bytes 1.3.0",
  "clap",
  "color-eyre",
- "crossterm",
  "dirs",
  "dyn-clone",
- "erased-serde",
  "eyre",
- "futures 0.3.25",
  "glob",
  "nix",
  "owo-colors",
@@ -822,21 +546,17 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sxd-document",
- "sxd-xpath",
  "tar",
  "target-lexicon",
  "term",
  "thiserror",
  "tokio",
- "tokio-util",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
  "typetag",
  "url",
  "valuable",
- "walkdir",
  "xz2",
 ]
 
@@ -1005,15 +725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -1079,15 +790,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1143,7 +845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
- "value-bag",
 ]
 
 [[package]]
@@ -1287,12 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,32 +1015,6 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "peresil"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
-
-[[package]]
-name = "pin-project"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1377,20 +1046,6 @@ dependencies = [
  "serde",
  "time",
  "xml-rs",
-]
-
-[[package]]
-name = "polling"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "166ca89eb77fd403230b9c156612965a81e094ec6ec3aa13663d4c8b113fa748"
-dependencies = [
- "autocfg",
- "cfg-if",
- "libc",
- "log",
- "wepoll-ffi",
- "windows-sys",
 ]
 
 [[package]]
@@ -1431,12 +1086,6 @@ checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1636,15 +1285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,18 +1317,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1756,27 +1396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,27 +1455,6 @@ checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
 dependencies = [
  "atty",
  "is_ci",
-]
-
-[[package]]
-name = "sxd-document"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078"
-dependencies = [
- "peresil",
- "typed-arena",
-]
-
-[[package]]
-name = "sxd-xpath"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e39da5d30887b5690e29de4c5ebb8ddff64ebd9933f98a01daaa4fd11b36ea"
-dependencies = [
- "peresil",
- "quick-error",
- "sxd-document",
 ]
 
 [[package]]
@@ -2006,7 +1604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures 0.1.31",
+ "futures",
  "log",
 ]
 
@@ -2148,12 +1746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "typed-arena"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
-
-[[package]]
 name = "typetag"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2253,37 +1845,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.0.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -2389,20 +1954,11 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2523,7 +2079,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
- "futures 0.1.31",
+ "futures",
  "lzma-sys",
  "tokio-io",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,24 +188,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
 dependencies = [
  "backtrace",
- "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
  "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
 ]
 
 [[package]]
@@ -1476,7 +1462,6 @@ checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
 ]
 
 [[package]]
@@ -1694,17 +1679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,11 +1703,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
  "valuable",
  "valuable-serde",
@@ -2056,15 +2028,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "xattr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,9 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -188,10 +191,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
 dependencies = [
  "backtrace",
+ "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
  "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -542,7 +559,6 @@ dependencies = [
  "tracing-subscriber",
  "typetag",
  "url",
- "valuable",
  "xz2",
 ]
 
@@ -1462,6 +1478,7 @@ checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1686,8 +1703,6 @@ checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
  "tracing-core",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -1707,8 +1722,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-serde",
- "valuable",
- "valuable-serde",
 ]
 
 [[package]]
@@ -1791,30 +1804,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-dependencies = [
- "valuable-derive",
-]
-
-[[package]]
-name = "valuable-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44690c645190cfce32f91a1582281654b2338c6073fa250b0949fd25c55b32"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "valuable-serde"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285cfff30cdabe26626736a54d989687dd9cab84f51f4048b61d6d0ae8b0907"
-dependencies = [
- "serde",
- "valuable",
-]
 
 [[package]]
 name = "version_check"
@@ -2028,6 +2017,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ semver = { version = "1.0.14", default-features = false, features = ["serde", "s
 term = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
-eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ], optional = true }
+eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,19 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 
 [features]
 default = ["cli"]
-cli = [ "eyre", "color-eyre", "crossterm", "clap", "tracing-subscriber", "tracing-error", "atty" ]
+cli = [ "eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty" ]
 
 [[bin]]
 name = "harmonic"
 required-features = [ "cli" ]
 
 [dependencies]
-async-tar = "0.4.2"
 async-trait = "0.1.57"
 atty = { version = "0.2.14", optional = true }
 bytes = "1.2.1"
 clap = { version = "4", features = ["derive", "env"], optional = true }
 color-eyre = { version = "0.6.2", optional = true }
-crossterm = { version = "0.25.0", features = ["event-stream"], optional = true }
 eyre = { version = "0.6.8", optional = true }
-futures = "0.3.24"
 glob = "0.3.0"
 nix = { version = "0.26.0", features = ["user", "fs", "process", "term"], default-features = false }
 owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
@@ -40,19 +37,14 @@ tar = "0.4.38"
 target-lexicon = "0.12.4"
 thiserror = "1.0.33"
 tokio = { version = "1.21.0", features = ["time", "io-std", "process", "fs", "signal", "tracing", "rt-multi-thread", "macros", "io-util", "parking_lot" ] }
-tokio-util = { version = "0.7", features = ["io"] }
 tracing = { version = "0.1.36", features = [ "valuable" ] }
 tracing-error = { version = "0.2.0", optional = true }
 tracing-subscriber = { version = "0.3.15", features = [ "json", "env-filter", "valuable" ], optional = true }
 url = { version = "2.3.1", features = ["serde"] }
 valuable = { version = "0.1.0", features = ["derive"] }
-walkdir = "2.3.2"
-sxd-xpath = "0.4.2"
 xz2 = { version = "0.1.7", features = ["static", "tokio"] }
-sxd-document = "0.3.2"
 plist = "1.3.1"
 dirs = "4.0.0"
-erased-serde = "0.3.23"
 typetag = "0.2.3"
 dyn-clone = "1.0.9"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,36 +20,36 @@ name = "harmonic"
 required-features = [ "cli" ]
 
 [dependencies]
-async-trait = "0.1.57"
-atty = { version = "0.2.14", optional = true }
-bytes = "1.2.1"
+async-trait = { version = "0.1.57", default-features = false }
+atty = { version = "0.2.14", default-features = false, optional = true }
+bytes = { version = "1.2.1", default-features = false }
 clap = { version = "4", features = ["derive", "env"], optional = true }
-color-eyre = { version = "0.6.2", optional = true }
-eyre = { version = "0.6.8", optional = true }
-glob = "0.3.0"
-nix = { version = "0.26.0", features = ["user", "fs", "process", "term"], default-features = false }
-owo-colors = { version = "3.5.0", features = [ "supports-colors" ] }
+color-eyre = { version = "0.6.2", default-features = false, optional = true }
+eyre = { version = "0.6.8", default-features = false, optional = true }
+glob = { version = "0.3.0", default-features = false }
+nix = { version = "0.26.0", default-features = false, features = ["user", "fs", "process", "term"] }
+owo-colors = { version = "3.5.0", default-features = false, features = [ "supports-colors" ] }
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream"] }
-serde = { version = "1.0.144", features = ["derive"] }
-serde_json = "1.0.85"
-serde_with = "2.0.1"
-tar = "0.4.38"
-target-lexicon = "0.12.4"
-thiserror = "1.0.33"
-tokio = { version = "1.21.0", features = ["time", "io-std", "process", "fs", "signal", "tracing", "rt-multi-thread", "macros", "io-util", "parking_lot" ] }
-tracing = { version = "0.1.36", features = [ "valuable" ] }
-tracing-error = { version = "0.2.0", optional = true }
-tracing-subscriber = { version = "0.3.15", features = [ "json", "env-filter", "valuable" ], optional = true }
-url = { version = "2.3.1", features = ["serde"] }
-valuable = { version = "0.1.0", features = ["derive"] }
-xz2 = { version = "0.1.7", features = ["static", "tokio"] }
-plist = "1.3.1"
-dirs = "4.0.0"
-typetag = "0.2.3"
-dyn-clone = "1.0.9"
-rand = "0.8.5"
-semver = { version = "1.0.14", features = ["serde"] }
-term = "0.7.0"
+serde = { version = "1.0.144", default-features = false, features = [ "derive" ] }
+serde_json = { version = "1.0.85", default-features = false }
+serde_with = { version = "2.0.1", default-features = false, features = [ "std", "macros" ] }
+tar = { version = "0.4.38", default-features = false }
+target-lexicon = { version = "0.12.4", default-features = false }
+thiserror = { version = "1.0.33", default-features = false }
+tokio = { version = "1.21.0", default-features = false, features = ["time", "io-std", "process", "fs", "signal", "tracing", "rt-multi-thread", "macros", "io-util", "parking_lot" ] }
+tracing = { version = "0.1.36", default-features = false, features = [ "std", "valuable", "attributes" ] }
+tracing-error = { version = "0.2.0", default-features = false, optional = true }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = [ "std", "registry", "fmt", "json", "ansi", "env-filter", "valuable" ], optional = true }
+url = { version = "2.3.1", default-features = false, features = ["serde"] }
+valuable = { version = "0.1.0", default-features = false, features = ["derive"] }
+xz2 = { version = "0.1.7", default-features = false, features = ["static", "tokio"] }
+plist = { version = "1.3.1", default-features = false, features = [ "serde" ]}
+dirs = { version = "4.0.0", default-features = false }
+typetag = { version = "0.2.3", default-features = false }
+dyn-clone = { version = "1.0.9", default-features = false }
+rand = { version = "0.8.5", default-features = false, features = [ "std", "std_rng" ] }
+semver = { version = "1.0.14", default-features = false, features = ["serde", "std"] }
+term = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
-eyre = "0.6.8"
+eyre = { version = "0.6.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ nix = { version = "0.26.0", default-features = false, features = ["user", "fs", 
 owo-colors = { version = "3.5.0", default-features = false, features = [ "supports-colors" ] }
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream"] }
 serde = { version = "1.0.144", default-features = false, features = [ "derive" ] }
-serde_json = { version = "1.0.85", default-features = false }
+serde_json = { version = "1.0.85", default-features = false, features = [ "std" ] }
 serde_with = { version = "2.0.1", default-features = false, features = [ "std", "macros" ] }
 tar = { version = "0.4.38", default-features = false }
 target-lexicon = { version = "0.12.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,26 +22,25 @@ required-features = [ "cli" ]
 [dependencies]
 async-trait = { version = "0.1.57", default-features = false }
 atty = { version = "0.2.14", default-features = false, optional = true }
-bytes = { version = "1.2.1", default-features = false }
-clap = { version = "4", features = ["derive", "env"], optional = true }
-color-eyre = { version = "0.6.2", default-features = false, optional = true }
-eyre = { version = "0.6.8", default-features = false, optional = true }
+bytes = { version = "1.2.1", default-features = false, features = ["std", "serde"] }
+clap = { version = "4", features = ["std", "color", "usage", "help", "error-context", "suggestions", "derive", "env"], optional = true }
+color-eyre = { version = "0.6.2", default-features = false, features = [ "track-caller", "tracing-error", "capture-spantrace", "color-spantrace" ], optional = true }
+eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ], optional = true }
 glob = { version = "0.3.0", default-features = false }
 nix = { version = "0.26.0", default-features = false, features = ["user", "fs", "process", "term"] }
 owo-colors = { version = "3.5.0", default-features = false, features = [ "supports-colors" ] }
 reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream"] }
-serde = { version = "1.0.144", default-features = false, features = [ "derive" ] }
+serde = { version = "1.0.144", default-features = false, features = [ "std", "derive" ] }
 serde_json = { version = "1.0.85", default-features = false, features = [ "std" ] }
 serde_with = { version = "2.0.1", default-features = false, features = [ "std", "macros" ] }
-tar = { version = "0.4.38", default-features = false }
-target-lexicon = { version = "0.12.4", default-features = false }
+tar = { version = "0.4.38", default-features = false, features = [ "xattr" ] }
+target-lexicon = { version = "0.12.4", default-features = false, features = [ "std" ] }
 thiserror = { version = "1.0.33", default-features = false }
 tokio = { version = "1.21.0", default-features = false, features = ["time", "io-std", "process", "fs", "signal", "tracing", "rt-multi-thread", "macros", "io-util", "parking_lot" ] }
-tracing = { version = "0.1.36", default-features = false, features = [ "std", "valuable", "attributes" ] }
-tracing-error = { version = "0.2.0", default-features = false, optional = true }
-tracing-subscriber = { version = "0.3.15", default-features = false, features = [ "std", "registry", "fmt", "json", "ansi", "env-filter", "valuable" ], optional = true }
+tracing = { version = "0.1.36", default-features = false, features = [ "std", "attributes" ] }
+tracing-error = { version = "0.2.0", default-features = false, optional = true, features = ["traced-error"] }
+tracing-subscriber = { version = "0.3.15", default-features = false, features = [ "std", "registry", "fmt", "json", "ansi", "env-filter" ], optional = true }
 url = { version = "2.3.1", default-features = false, features = ["serde"] }
-valuable = { version = "0.1.0", default-features = false, features = ["derive"] }
 xz2 = { version = "0.1.7", default-features = false, features = ["static", "tokio"] }
 plist = { version = "1.3.1", default-features = false, features = [ "serde" ]}
 dirs = { version = "4.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ semver = { version = "1.0.14", default-features = false, features = ["serde", "s
 term = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
-eyre = { version = "0.6.8", default-features = false }
+eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ], optional = true }

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
               doCheck = true;
               doDoc = true;
               doDocFail = true;
-              RUSTFLAGS = "--cfg tracing_unstable --cfg tokio_unstable";
+              RUSTFLAGS = "--cfg tokio_unstable";
               cargoTestOptions = f: f ++ [ "--all" ];
 
               override = { preBuild ? "", ... }: {

--- a/src/cli/arg/instrumentation.rs
+++ b/src/cli/arg/instrumentation.rs
@@ -3,9 +3,8 @@ use eyre::WrapErr;
 use std::error::Error;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use valuable::Valuable;
 
-#[derive(Clone, Default, Debug, clap::ValueEnum, Valuable)]
+#[derive(Clone, Default, Debug, clap::ValueEnum)]
 pub enum Logger {
     #[default]
     Compact,
@@ -26,7 +25,7 @@ impl std::fmt::Display for Logger {
     }
 }
 
-#[derive(clap::Args, Debug, Valuable)]
+#[derive(clap::Args, Debug)]
 pub struct Instrumentation {
     /// Enable debug logs, -vv for trace
     #[clap(short = 'v', env = "HARMONIC_VERBOSITY", long, action = clap::ArgAction::Count, global = true)]


### PR DESCRIPTION
Minimize dependencies from `cargo machete`.

This ultimately has no net change in binary size:

```
$ git checkout main
$ nix build .#harmonicStatic -L --out-link demo-main
$ du -h demo-main/bin/
15M     demo-main/bin/
$ nix build .#harmonicStatic -L --out-link demo-min-dep
$ du -h demo-min-dep/bin/
15M     demo-min-dep/bin/
```

However my build time on `min-deps`:

```
❯ time cargo build -q

________________________________________________________
Executed in   27.64 secs    fish           external
   usr time  157.49 secs    0.00 micros  157.49 secs
   sys time   39.80 secs  777.00 micros   39.80 secs
```

vs `main`:

```
❯ time cargo build -q

________________________________________________________
Executed in   38.63 secs    fish           external
   usr time  136.83 secs    5.00 micros  136.83 secs
   sys time   18.05 secs  998.00 micros   18.04 secs
```

So this nets decent build time speedup.