### PR TITLE
minimize size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,8 @@ term = "0.7.0"
 
 [dev-dependencies]
 eyre = "0.6.8"
+
+[profile.release]
+strip = true  # Automatically strip symbols from the binary.
+opt-level = "z"  # Optimize for size.
+lto = true


### PR DESCRIPTION
Post:

```
harmonic on  main [=$?] is 📦 v0.0.0-unreleased via 🦀 v1.65.0 via ❄️  impure (nix-install-shell) took 2m31s 
❯ ls -lah x86_64-linux/bin/
total 6.9M
dr-xr-xr-x 1 root root   44 Dec 31  1969 ./
dr-xr-xr-x 1 root root    6 Dec 31  1969 ../
-r-xr-xr-x 1 root root 6.9M Dec 31  1969 harmonic*
-r-xr-xr-x 1 root root  16K Dec 31  1969 nix-install.sh*
```

Pre:

```
harmonic on  main [=$?] is 📦 v0.0.0-unreleased via 🦀 v1.65.0 via ❄️  impure (nix-install-shell) 
❯ ls -lah demo-main/bin
total 15M
dr-xr-xr-x 1 root root  44 Dec 31  1969 ./
dr-xr-xr-x 1 root root   6 Dec 31  1969 ../
-r-xr-xr-x 1 root root 15M Dec 31  1969 harmonic*
-r-xr-xr-x 1 root root 16K Dec 31  1969 nix-install.sh*
```